### PR TITLE
merge v0.2.0 changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-cache"
-version = "0.1.1"
+version = "0.2.0"
 description = "An HTTP caching middleware"
 authors = ["Christian Haynes <06chaynes@gmail.com>", "Kat Marchán <kzm@zkat.tech>"]
 repository = "https://github.com/06chaynes/http-cache.git"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 <img align="right" src="https://raw.githubusercontent.com/06chaynes/http-cache/latest/.assets/images/http-cache_logo_bluegreen.svg" height="150px" alt="the http-cache logo">
 
-A caching middleware that follows HTTP caching rules, thanks to [http-cache-semantics](https://github.com/kornelski/rusty-http-cache-semantics). By default, it uses [cacache](https://github.com/zkat/cacache-rs) as the backend cache manager.
+A caching middleware that follows HTTP caching rules,
+thanks to [http-cache-semantics](https://github.com/kornelski/rusty-http-cache-semantics).
+By default, it uses [cacache](https://github.com/zkat/cacache-rs) as the backend cache manager.
 
 ## Supported Clients
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img align="right" src="https://raw.githubusercontent.com/06chaynes/http-cache/latest/.assets/images/http-cache_logo_bluegreen.svg" height="150px" alt="the http-cache logo">
 
-A caching middleware that follows HTTP caching rules, thanks to [http-cache-semantics](https://github.com/kornelski/rusty-http-cache-semantics). By default it uses [cacache](https://github.com/zkat/cacache-rs) as the backend cache manager.
+A caching middleware that follows HTTP caching rules, thanks to [http-cache-semantics](https://github.com/kornelski/rusty-http-cache-semantics). By default, it uses [cacache](https://github.com/zkat/cacache-rs) as the backend cache manager.
 
 ## Supported Clients
 
@@ -34,7 +34,8 @@ async fn main() -> surf::Result<()> {
     surf::client()
         .with(Cache {
             mode: CacheMode::Default,
-            cache_manager: CACacheManager::default(),
+            manager: CACacheManager::default(),
+            options: None,
         })
         .send(req)
         .await?;
@@ -54,7 +55,8 @@ async fn main() -> Result<()> {
     let client = ClientBuilder::new(Client::new())
         .with(Cache {
             mode: CacheMode::Default,
-            cache_manager: CACacheManager::default(),
+            manager: CACacheManager::default(),
+            options: None,
         })
         .build();
     client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,15 @@
 //!     surf::client()
 //!         .with(Cache {
 //!             mode: CacheMode::Default,
-//!             cache_manager: CACacheManager::default(),
+//!             manager: CACacheManager::default(),
+//!             options: None,
 //!         })
 //!         .send(req)
 //!         .await?;
 //!     Ok(())
 //! }
-//!
 //! ```
+//!
 //! ## Example - Reqwest (requires feature: `client-reqwest`)
 //!
 //! ```ignore
@@ -32,7 +33,8 @@
 //!     let client = ClientBuilder::new(Client::new())
 //!         .with(Cache {
 //!             mode: CacheMode::Default,
-//!             cache_manager: CACacheManager::default(),
+//!             manager: CACacheManager::default(),
+//!             options: None,
 //!         })
 //!         .build();
 //!     client
@@ -59,6 +61,8 @@ pub use error::CacheError;
 
 #[cfg(feature = "manager-cacache")]
 pub use managers::cacache::CACacheManager;
+
+pub use http_cache_semantics::CacheOptions;
 
 use http::{header::CACHE_CONTROL, request, response, StatusCode};
 use std::{collections::HashMap, str::FromStr, time::SystemTime};
@@ -184,6 +188,11 @@ impl HttpResponse {
 pub(crate) trait Middleware {
     fn is_method_get_head(&self) -> bool;
     fn policy(&self, response: &HttpResponse) -> Result<CachePolicy>;
+    fn policy_with_options(
+        &self,
+        response: &HttpResponse,
+        options: CacheOptions,
+    ) -> Result<CachePolicy>;
     fn update_headers(&mut self, parts: request::Parts) -> Result<()>;
     fn set_no_cache(&mut self) -> Result<()>;
     fn parts(&self) -> Result<request::Parts>;
@@ -251,11 +260,13 @@ pub struct Cache<T: CacheManager + Send + Sync + 'static> {
     /// Determines the manager behavior
     pub mode: CacheMode,
     /// Manager instance that implements the CacheManager trait
-    pub cache_manager: T,
+    pub manager: T,
+    /// Override the default cache options
+    pub options: Option<CacheOptions>,
 }
 
+#[allow(dead_code)]
 impl<T: CacheManager + Send + Sync + 'static> Cache<T> {
-    #[allow(dead_code)]
     pub(crate) async fn run(
         &self,
         mut middleware: impl Middleware,
@@ -266,10 +277,8 @@ impl<T: CacheManager + Send + Sync + 'static> Cache<T> {
         if !is_cacheable {
             return middleware.remote_fetch().await;
         }
-        if let Some(store) = self
-            .cache_manager
-            .get(&middleware.method()?, middleware.url()?)
-            .await?
+        if let Some(store) =
+            self.manager.get(&middleware.method()?, middleware.url()?).await?
         {
             let (mut res, policy) = store;
             let res_url = res.url.clone();
@@ -325,13 +334,15 @@ impl<T: CacheManager + Send + Sync + 'static> Cache<T> {
         }
     }
 
-    #[allow(dead_code)]
     async fn remote_fetch(
         &self,
         middleware: &mut impl Middleware,
     ) -> Result<HttpResponse> {
         let res = middleware.remote_fetch().await?;
-        let policy = middleware.policy(&res)?;
+        let policy = match self.options {
+            Some(options) => middleware.policy_with_options(&res, options)?,
+            None => middleware.policy(&res)?,
+        };
         let is_cacheable = middleware.is_method_get_head()
             && self.mode != CacheMode::NoStore
             && self.mode != CacheMode::Reload
@@ -339,11 +350,11 @@ impl<T: CacheManager + Send + Sync + 'static> Cache<T> {
             && policy.is_storable();
         if is_cacheable {
             Ok(self
-                .cache_manager
+                .manager
                 .put(&middleware.method()?, middleware.url()?, res, policy)
                 .await?)
         } else if !middleware.is_method_get_head() {
-            self.cache_manager
+            self.manager
                 .delete(&middleware.method()?, middleware.url()?)
                 .await?;
             Ok(res)
@@ -352,7 +363,6 @@ impl<T: CacheManager + Send + Sync + 'static> Cache<T> {
         }
     }
 
-    #[allow(dead_code)]
     async fn conditional_fetch(
         &self,
         mut middleware: impl Middleware,
@@ -402,7 +412,7 @@ impl<T: CacheManager + Send + Sync + 'static> Cache<T> {
                         }
                     }
                     let res = self
-                        .cache_manager
+                        .manager
                         .put(
                             &middleware.method()?,
                             &req_url,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,9 +267,7 @@ pub enum CacheMode {
     ForceCache,
     /// Uses any response in the HTTP cache matching the request,
     /// not paying attention to staleness. If there was no response,
-    /// it returns a network error. (Can only be used when request’s mode is "same-origin".
-    /// Any cached redirects will be followed assuming request’s redirect mode is "follow"
-    /// and the redirects do not violate request’s mode.)
+    /// it returns a network error.
     OnlyIfCached,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,14 @@
 //! [`http-cache-semantics`](https://github.com/kornelski/rusty-http-cache-semantics).
 //! By default, it uses [`cacache`](https://github.com/zkat/cacache-rs) as the backend cache manager.
 //!
-//! ## Example - Surf (requires feature: `client-surf`)
+//! ## Supported Clients
+//!
+//! - **Surf** **Should likely be registered after any middleware modifying the request*
+//! - **Reqwest** **Uses [reqwest-middleware](https://github.com/TrueLayer/reqwest-middleware) for middleware support*
+//!
+//! ## Examples
+//!
+//! ### Surf (requires feature: `client-surf`)
 //!
 //! ```ignore
 //! use http_cache::{Cache, CacheMode, CACacheManager};
@@ -22,7 +29,7 @@
 //! }
 //! ```
 //!
-//! ## Example - Reqwest (requires feature: `client-reqwest`)
+//! ### Reqwest (requires feature: `client-reqwest`)
 //!
 //! ```ignore
 //! use reqwest::Client;
@@ -45,6 +52,15 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## Features
+//!
+//! The following features are available. By default `manager-cacache` is enabled.
+//!
+//! - `manager-cacache` (default): use [cacache](https://github.com/zkat/cacache-rs),
+//! a high-performance disk cache, for the manager backend.
+//! - `client-surf` (disabled): enables [surf](https://github.com/http-rs/surf) client support.
+//! - `client-reqwest` (disabled): enables [reqwest](https://github.com/seanmonstar/reqwest) client support.
 #![forbid(unsafe_code, future_incompatible)]
 #![deny(
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,11 @@
     missing_copy_implementations,
     nonstandard_style,
     unused_qualifications,
-    rustdoc::missing_doc_code_examples
+    unused_import_braces,
+    unused_extern_crates,
+    rustdoc::missing_doc_code_examples,
+    trivial_casts,
+    trivial_numeric_casts
 )]
 mod error;
 mod managers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-//! A caching middleware that follows HTTP caching rules.
-//! By default it uses [`cacache`](https://github.com/zkat/cacache-rs) as the backend cache manager.
+//! A caching middleware that follows HTTP caching rules, thanks to
+//! [`http-cache-semantics`](https://github.com/kornelski/rusty-http-cache-semantics).
+//! By default, it uses [`cacache`](https://github.com/zkat/cacache-rs) as the backend cache manager.
 //!
 //! ## Example - Surf (requires feature: `client-surf`)
 //!
@@ -62,6 +63,8 @@ pub use error::CacheError;
 #[cfg(feature = "manager-cacache")]
 pub use managers::cacache::CACacheManager;
 
+/// Options struct provided by
+/// [`http-cache-semantics`](https://github.com/kornelski/rusty-http-cache-semantics).
 pub use http_cache_semantics::CacheOptions;
 
 use http::{header::CACHE_CONTROL, request, response, StatusCode};
@@ -71,7 +74,7 @@ use http_cache_semantics::{AfterResponse, BeforeRequest, CachePolicy};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-/// A `Result` typedef to use with the `CacheError` type
+/// A `Result` typedef to use with the [`CacheError`] type
 pub type Result<T> = std::result::Result<T, CacheError>;
 
 /// Represents an HTTP version
@@ -254,14 +257,16 @@ pub enum CacheMode {
     OnlyIfCached,
 }
 
-/// Caches requests according to http spec
+/// Caches requests according to http spec.
 #[derive(Debug, Clone)]
 pub struct Cache<T: CacheManager + Send + Sync + 'static> {
-    /// Determines the manager behavior
+    /// Determines the manager behavior.
     pub mode: CacheMode,
-    /// Manager instance that implements the CacheManager trait
+    /// Manager instance that implements the [`CacheManager`] trait.
+    /// By default, a manager implementation with [`cacache`](https://github.com/zkat/cacache-rs)
+    /// as the backend has been provided, see [`CACacheManager`].
     pub manager: T,
-    /// Override the default cache options
+    /// Override the default cache options.
     pub options: Option<CacheOptions>,
 }
 


### PR DESCRIPTION
Sweet it's breaking changes time! 

I tried to get around this but I really wanted to add the ability to override the cache options and it was best added in the Cache struct. The `options` field has now been added but is wrapped in an Option to make using the default options relatively easy (I heard you like options so I put an options in an Option). Since I was already breaking things I decided to change a field name as well, shortening `cache_manager` to `manager`.