### PR TITLE
reqwest: do not interpret the response as text

### DIFF
--- a/src/middleware/reqwest.rs
+++ b/src/middleware/reqwest.rs
@@ -107,7 +107,7 @@ impl Middleware for ReqwestMiddleware<'_> {
         let url = res.url().clone();
         let status = res.status().into();
         let version = res.version();
-        let body: Vec<u8> = res.text().await?.into_bytes();
+        let body: Vec<u8> = res.bytes().await?.to_vec();
         Ok(HttpResponse {
             body,
             headers,


### PR DESCRIPTION
Otherwise, if you fetch images, for example, they will be corrupted.