### PR TITLE
Adds x-cache headers for hit/miss info, lots o bug fixes

### DIFF
--- a/http-cache-reqwest/Cargo.toml
+++ b/http-cache-reqwest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-cache-reqwest"
-version = "0.2.2"
+version = "0.3.0"
 description = "http-cache middleware implementation for reqwest"
 authors = ["Christian Haynes <06chaynes@gmail.com>", "Kat Marchán <kzm@zkat.tech>"]
 repository = "https://github.com/06chaynes/http-cache.git"
@@ -26,7 +26,7 @@ url = { version = "2.2.2", features = ["serde"] }
 
 [dependencies.http-cache]
 path = "../http-cache"
-version = "0.4.3"
+version = "0.5.0"
 
 [dev-dependencies]
 tokio = { version = "1.16.1", features = ["macros", "rt-multi-thread"] }

--- a/http-cache-surf/Cargo.toml
+++ b/http-cache-surf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-cache-surf"
-version = "0.2.2"
+version = "0.3.0"
 description = "http-cache middleware implementation for surf"
 authors = ["Christian Haynes <06chaynes@gmail.com>", "Kat Marchán <kzm@zkat.tech>"]
 repository = "https://github.com/06chaynes/http-cache.git"
@@ -25,7 +25,7 @@ url = { version = "2.2.2", features = ["serde"] }
 
 [dependencies.http-cache]
 path = "../http-cache"
-version = "0.4.3"
+version = "0.5.0"
 features = ["with-http-types"]
 
 [dev-dependencies]

--- a/http-cache-tests/Cargo.toml
+++ b/http-cache-tests/Cargo.toml
@@ -20,13 +20,13 @@ wiremock = "0.5.10"
 
 [dependencies.http-cache]
 path = "../http-cache"
-version = "0.4.3"
+version = "0.5.0"
 features = ["with-http-types", "manager-moka"]
 
 [dependencies.http-cache-reqwest]
 path = "../http-cache-reqwest"
-version = "0.2.2"
+version = "0.3.0"
 
 [dependencies.http-cache-surf]
 path = "../http-cache-surf"
-version = "0.2.2"
+version = "0.3.0"

--- a/http-cache-tests/src/client_surf.rs
+++ b/http-cache-tests/src/client_surf.rs
@@ -293,7 +293,7 @@ async fn revalidation_304() -> surf::Result<()> {
     let header = res.header("x-cache-lookup");
     assert_eq!(header.unwrap(), "HIT");
     let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(header.unwrap(), "HIT");
     Ok(())
 }
 

--- a/http-cache-tests/src/client_surf.rs
+++ b/http-cache-tests/src/client_surf.rs
@@ -31,6 +31,9 @@ async fn default_mode() -> surf::Result<()> {
     // Hot pass to make sure the expect response was returned
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, TEST_BODY);
+    let header = res.header("x-cache");
+    assert!(header.is_some());
+    assert_eq!(header.unwrap(), "HIT");
     Ok(())
 }
 

--- a/http-cache-tests/src/client_surf.rs
+++ b/http-cache-tests/src/client_surf.rs
@@ -23,6 +23,9 @@ async fn default_mode() -> surf::Result<()> {
 
     // Cold pass to load cache
     let res = client.send(req.clone()).await?;
+    let header = res.header("x-cache-lookup");
+    assert!(header.is_some());
+    assert_eq!(header.unwrap(), "MISS");
     let header = res.header("x-cache");
     assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
@@ -34,6 +37,9 @@ async fn default_mode() -> surf::Result<()> {
     // Hot pass to make sure the expect response was returned
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, TEST_BODY);
+    let header = res.header("x-cache-lookup");
+    assert!(header.is_some());
+    assert_eq!(header.unwrap(), "HIT");
     let header = res.header("x-cache");
     assert!(header.is_some());
     assert_eq!(header.unwrap(), "HIT");
@@ -135,6 +141,9 @@ async fn no_store_mode() -> surf::Result<()> {
 
     // To verify our endpoint receives the request rather than a cache hit
     let res = client.send(req.clone()).await?;
+    let header = res.header("x-cache-lookup");
+    assert!(header.is_some());
+    assert_eq!(header.unwrap(), "MISS");
     let header = res.header("x-cache");
     assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
@@ -279,6 +288,12 @@ async fn revalidation_304() -> surf::Result<()> {
     // Hot pass to make sure revalidation request was sent
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, TEST_BODY);
+    let header = res.header("x-cache-lookup");
+    assert!(header.is_some());
+    assert_eq!(header.unwrap(), "HIT");
+    let header = res.header("x-cache");
+    assert!(header.is_some());
+    assert_eq!(header.unwrap(), "MISS");
     Ok(())
 }
 

--- a/http-cache-tests/src/client_surf.rs
+++ b/http-cache-tests/src/client_surf.rs
@@ -140,7 +140,7 @@ async fn no_store_mode() -> surf::Result<()> {
     assert!(data.is_none());
 
     // To verify our endpoint receives the request rather than a cache hit
-    let res = client.send(req.clone()).await?;
+    let res = client.send(req).await?;
     let header = res.header("x-cache-lookup");
     assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
@@ -180,7 +180,7 @@ async fn no_cache_mode() -> surf::Result<()> {
     assert!(data.is_some());
 
     // To verify our endpoint receives the request rather than a cache hit
-    let res = client.send(req.clone()).await?;
+    let res = client.send(req).await?;
     let header = res.header("x-cache-lookup");
     assert!(header.is_some());
     assert_eq!(header.unwrap(), "HIT");
@@ -214,7 +214,7 @@ async fn force_cache_mode() -> surf::Result<()> {
     assert!(data.is_some());
 
     // Should result in a cache hit and no remote request
-    client.send(req.clone()).await?;
+    client.send(req).await?;
     Ok(())
 }
 
@@ -318,7 +318,7 @@ mod only_if_cached_mode {
         }));
 
         // Should result in a cache miss and no remote request
-        client.send(req.clone()).await?;
+        client.send(req).await?;
 
         // Try to load cached object
         let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -357,7 +357,7 @@ mod only_if_cached_mode {
         }));
 
         // Should result in a cache hit and no remote request
-        let mut res = client.send(req.clone()).await?;
+        let mut res = client.send(req).await?;
         assert_eq!(res.body_bytes().await?, TEST_BODY);
         Ok(())
     }

--- a/http-cache-tests/src/client_surf.rs
+++ b/http-cache-tests/src/client_surf.rs
@@ -23,10 +23,8 @@ async fn default_mode() -> surf::Result<()> {
 
     // Cold pass to load cache
     let res = client.send(req.clone()).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "MISS");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
 
     // Try to load cached object
     let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -35,10 +33,8 @@ async fn default_mode() -> surf::Result<()> {
     // Hot pass to make sure the expect response was returned
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, TEST_BODY);
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "HIT");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "HIT");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "HIT");
+    assert_eq!(res.header("x-cache").unwrap(), "HIT");
     Ok(())
 }
 
@@ -89,10 +85,8 @@ async fn default_mode_no_cache_response() -> surf::Result<()> {
 
     // Cold pass to load cache
     let res = client.send(req.clone()).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "MISS");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
 
     // Try to load cached object
     let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -101,10 +95,8 @@ async fn default_mode_no_cache_response() -> surf::Result<()> {
     // Hot pass to make sure the expect response was returned
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, TEST_BODY);
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "HIT");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "HIT");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
     Ok(())
 }
 
@@ -133,10 +125,8 @@ async fn no_store_mode() -> surf::Result<()> {
 
     // To verify our endpoint receives the request rather than a cache hit
     let res = client.send(req).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "MISS");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
     Ok(())
 }
 
@@ -158,10 +148,8 @@ async fn no_cache_mode() -> surf::Result<()> {
 
     // Remote request and should cache
     let res = client.send(req.clone()).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "MISS");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
 
     // Try to load cached object
     let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -169,10 +157,8 @@ async fn no_cache_mode() -> surf::Result<()> {
 
     // To verify our endpoint receives the request rather than a cache hit
     let res = client.send(req).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "HIT");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "HIT");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
     Ok(())
 }
 
@@ -194,10 +180,8 @@ async fn force_cache_mode() -> surf::Result<()> {
 
     // Should result in a cache miss and a remote request
     let res = client.send(req.clone()).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "MISS");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
 
     // Try to load cached object
     let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -205,10 +189,8 @@ async fn force_cache_mode() -> surf::Result<()> {
 
     // Should result in a cache hit and no remote request
     let res = client.send(req).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "HIT");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "HIT");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "HIT");
+    assert_eq!(res.header("x-cache").unwrap(), "HIT");
     Ok(())
 }
 
@@ -235,10 +217,8 @@ async fn delete_after_non_get_head_method_request() -> surf::Result<()> {
 
     // Cold pass to load cache
     let res = client.send(req_get).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "MISS");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
 
     // Try to load cached object
     let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -274,10 +254,8 @@ async fn revalidation_304() -> surf::Result<()> {
 
     // Cold pass to load cache
     let res = client.send(req.clone()).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "MISS");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
 
     drop(mock_guard);
 
@@ -290,10 +268,8 @@ async fn revalidation_304() -> surf::Result<()> {
     // Hot pass to make sure revalidation request was sent
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, TEST_BODY);
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "HIT");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "HIT");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "HIT");
+    assert_eq!(res.header("x-cache").unwrap(), "HIT");
     Ok(())
 }
 
@@ -316,10 +292,8 @@ async fn revalidation_200() -> surf::Result<()> {
 
     // Cold pass to load cache
     let res = client.send(req.clone()).await?;
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "MISS");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
 
     drop(mock_guard);
 
@@ -332,10 +306,8 @@ async fn revalidation_200() -> surf::Result<()> {
     // Hot pass to make sure revalidation request was sent
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, b"updated");
-    let header = res.header("x-cache-lookup");
-    assert_eq!(header.unwrap(), "HIT");
-    let header = res.header("x-cache");
-    assert_eq!(header.unwrap(), "MISS");
+    assert_eq!(res.header("x-cache-lookup").unwrap(), "HIT");
+    assert_eq!(res.header("x-cache").unwrap(), "MISS");
     Ok(())
 }
 
@@ -361,10 +333,8 @@ mod only_if_cached_mode {
 
         // Should result in a cache miss and no remote request
         let res = client.send(req).await?;
-        let header = res.header("x-cache-lookup");
-        assert_eq!(header.unwrap(), "MISS");
-        let header = res.header("x-cache");
-        assert_eq!(header.unwrap(), "MISS");
+        assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+        assert_eq!(res.header("x-cache").unwrap(), "MISS");
 
         // Try to load cached object
         let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -390,10 +360,8 @@ mod only_if_cached_mode {
 
         // Cold pass to load the cache
         let res = client.send(req.clone()).await?;
-        let header = res.header("x-cache-lookup");
-        assert_eq!(header.unwrap(), "MISS");
-        let header = res.header("x-cache");
-        assert_eq!(header.unwrap(), "MISS");
+        assert_eq!(res.header("x-cache-lookup").unwrap(), "MISS");
+        assert_eq!(res.header("x-cache").unwrap(), "MISS");
 
         // Try to load cached object
         let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -409,10 +377,8 @@ mod only_if_cached_mode {
         // Should result in a cache hit and no remote request
         let mut res = client.send(req).await?;
         assert_eq!(res.body_bytes().await?, TEST_BODY);
-        let header = res.header("x-cache-lookup");
-        assert_eq!(header.unwrap(), "HIT");
-        let header = res.header("x-cache");
-        assert_eq!(header.unwrap(), "HIT");
+        assert_eq!(res.header("x-cache-lookup").unwrap(), "HIT");
+        assert_eq!(res.header("x-cache").unwrap(), "HIT");
         Ok(())
     }
 }

--- a/http-cache-tests/src/client_surf.rs
+++ b/http-cache-tests/src/client_surf.rs
@@ -24,10 +24,8 @@ async fn default_mode() -> surf::Result<()> {
     // Cold pass to load cache
     let res = client.send(req.clone()).await?;
     let header = res.header("x-cache-lookup");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
     let header = res.header("x-cache");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
 
     // Try to load cached object
@@ -38,10 +36,8 @@ async fn default_mode() -> surf::Result<()> {
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, TEST_BODY);
     let header = res.header("x-cache-lookup");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "HIT");
     let header = res.header("x-cache");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "HIT");
     Ok(())
 }
@@ -94,10 +90,8 @@ async fn default_mode_no_cache_response() -> surf::Result<()> {
     // Cold pass to load cache
     let res = client.send(req.clone()).await?;
     let header = res.header("x-cache-lookup");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
     let header = res.header("x-cache");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
 
     // Try to load cached object
@@ -108,10 +102,8 @@ async fn default_mode_no_cache_response() -> surf::Result<()> {
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, TEST_BODY);
     let header = res.header("x-cache-lookup");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "HIT");
     let header = res.header("x-cache");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
     Ok(())
 }
@@ -142,10 +134,8 @@ async fn no_store_mode() -> surf::Result<()> {
     // To verify our endpoint receives the request rather than a cache hit
     let res = client.send(req).await?;
     let header = res.header("x-cache-lookup");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
     let header = res.header("x-cache");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
     Ok(())
 }
@@ -169,10 +159,8 @@ async fn no_cache_mode() -> surf::Result<()> {
     // Remote request and should cache
     let res = client.send(req.clone()).await?;
     let header = res.header("x-cache-lookup");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
     let header = res.header("x-cache");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
 
     // Try to load cached object
@@ -182,10 +170,8 @@ async fn no_cache_mode() -> surf::Result<()> {
     // To verify our endpoint receives the request rather than a cache hit
     let res = client.send(req).await?;
     let header = res.header("x-cache-lookup");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "HIT");
     let header = res.header("x-cache");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
     Ok(())
 }
@@ -207,14 +193,22 @@ async fn force_cache_mode() -> surf::Result<()> {
     }));
 
     // Should result in a cache miss and a remote request
-    client.send(req.clone()).await?;
+    let res = client.send(req.clone()).await?;
+    let header = res.header("x-cache-lookup");
+    assert_eq!(header.unwrap(), "MISS");
+    let header = res.header("x-cache");
+    assert_eq!(header.unwrap(), "MISS");
 
     // Try to load cached object
     let data = manager.get(GET, &Url::parse(&url)?).await?;
     assert!(data.is_some());
 
     // Should result in a cache hit and no remote request
-    client.send(req).await?;
+    let res = client.send(req).await?;
+    let header = res.header("x-cache-lookup");
+    assert_eq!(header.unwrap(), "HIT");
+    let header = res.header("x-cache");
+    assert_eq!(header.unwrap(), "HIT");
     Ok(())
 }
 
@@ -240,7 +234,11 @@ async fn delete_after_non_get_head_method_request() -> surf::Result<()> {
     }));
 
     // Cold pass to load cache
-    client.send(req_get).await?;
+    let res = client.send(req_get).await?;
+    let header = res.header("x-cache-lookup");
+    assert_eq!(header.unwrap(), "MISS");
+    let header = res.header("x-cache");
+    assert_eq!(header.unwrap(), "MISS");
 
     // Try to load cached object
     let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -275,7 +273,11 @@ async fn revalidation_304() -> surf::Result<()> {
     }));
 
     // Cold pass to load cache
-    client.send(req.clone()).await?;
+    let res = client.send(req.clone()).await?;
+    let header = res.header("x-cache-lookup");
+    assert_eq!(header.unwrap(), "MISS");
+    let header = res.header("x-cache");
+    assert_eq!(header.unwrap(), "MISS");
 
     drop(mock_guard);
 
@@ -289,10 +291,8 @@ async fn revalidation_304() -> surf::Result<()> {
     let mut res = client.send(req).await?;
     assert_eq!(res.body_bytes().await?, TEST_BODY);
     let header = res.header("x-cache-lookup");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "HIT");
     let header = res.header("x-cache");
-    assert!(header.is_some());
     assert_eq!(header.unwrap(), "MISS");
     Ok(())
 }
@@ -318,7 +318,11 @@ mod only_if_cached_mode {
         }));
 
         // Should result in a cache miss and no remote request
-        client.send(req).await?;
+        let res = client.send(req).await?;
+        let header = res.header("x-cache-lookup");
+        assert_eq!(header.unwrap(), "MISS");
+        let header = res.header("x-cache");
+        assert_eq!(header.unwrap(), "MISS");
 
         // Try to load cached object
         let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -343,7 +347,11 @@ mod only_if_cached_mode {
         }));
 
         // Cold pass to load the cache
-        client.send(req.clone()).await?;
+        let res = client.send(req.clone()).await?;
+        let header = res.header("x-cache-lookup");
+        assert_eq!(header.unwrap(), "MISS");
+        let header = res.header("x-cache");
+        assert_eq!(header.unwrap(), "MISS");
 
         // Try to load cached object
         let data = manager.get(GET, &Url::parse(&url)?).await?;
@@ -359,6 +367,10 @@ mod only_if_cached_mode {
         // Should result in a cache hit and no remote request
         let mut res = client.send(req).await?;
         assert_eq!(res.body_bytes().await?, TEST_BODY);
+        let header = res.header("x-cache-lookup");
+        assert_eq!(header.unwrap(), "HIT");
+        let header = res.header("x-cache");
+        assert_eq!(header.unwrap(), "HIT");
         Ok(())
     }
 }

--- a/http-cache-tests/src/client_surf.rs
+++ b/http-cache-tests/src/client_surf.rs
@@ -297,6 +297,48 @@ async fn revalidation_304() -> surf::Result<()> {
     Ok(())
 }
 
+#[async_std::test]
+async fn revalidation_200() -> surf::Result<()> {
+    let mock_server = MockServer::start().await;
+    let m = build_mock("public, must-revalidate", TEST_BODY, 200, 1);
+    let m_200 = build_mock("public, must-revalidate", b"updated", 200, 1);
+    let mock_guard = mock_server.register_as_scoped(m).await;
+    let url = format!("{}/", &mock_server.uri());
+    let manager = Arc::new(MokaManager::default());
+    let req = Request::new(Method::Get, Url::parse(&url)?);
+
+    // Construct Surf client with cache defaults
+    let client = Client::new().with(Cache(HttpCache {
+        mode: CacheMode::Default,
+        manager: Arc::clone(&manager),
+        options: None,
+    }));
+
+    // Cold pass to load cache
+    let res = client.send(req.clone()).await?;
+    let header = res.header("x-cache-lookup");
+    assert_eq!(header.unwrap(), "MISS");
+    let header = res.header("x-cache");
+    assert_eq!(header.unwrap(), "MISS");
+
+    drop(mock_guard);
+
+    let _mock_guard = mock_server.register_as_scoped(m_200).await;
+
+    // Try to load cached object
+    let data = manager.get(GET, &Url::parse(&url)?).await?;
+    assert!(data.is_some());
+
+    // Hot pass to make sure revalidation request was sent
+    let mut res = client.send(req).await?;
+    assert_eq!(res.body_bytes().await?, b"updated");
+    let header = res.header("x-cache-lookup");
+    assert_eq!(header.unwrap(), "HIT");
+    let header = res.header("x-cache");
+    assert_eq!(header.unwrap(), "MISS");
+    Ok(())
+}
+
 #[cfg(test)]
 mod only_if_cached_mode {
     use super::*;

--- a/http-cache/Cargo.toml
+++ b/http-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-cache"
-version = "0.4.3"
+version = "0.5.0"
 description = "An HTTP caching middleware"
 authors = ["Christian Haynes <06chaynes@gmail.com>", "Kat Marchán <kzm@zkat.tech>"]
 repository = "https://github.com/06chaynes/http-cache.git"

--- a/http-cache/src/lib.rs
+++ b/http-cache/src/lib.rs
@@ -373,7 +373,6 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
             .await?
         {
             let (mut res, policy) = store;
-            res.set_cache_lookup_status_header(HitOrMiss::HIT)?;
             let res_url = res.url.clone();
             if let Some(warning_code) = res.warning_code() {
                 // https://tools.ietf.org/html/rfc7234#section-4.3.4
@@ -482,6 +481,7 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
             BeforeRequest::Fresh(parts) => {
                 cached_res.update_headers(parts)?;
                 cached_res.set_cache_status_header(HitOrMiss::HIT)?;
+                cached_res.set_cache_lookup_status_header(HitOrMiss::HIT)?;
                 return Ok(cached_res);
             }
             BeforeRequest::Stale { request: parts, matches } => {
@@ -530,6 +530,7 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                         )
                         .await?;
                     res.set_cache_status_header(HitOrMiss::MISS)?;
+                    res.set_cache_lookup_status_header(HitOrMiss::HIT)?;
                     Ok(res)
                 } else {
                     cached_res.set_cache_status_header(HitOrMiss::HIT)?;

--- a/http-cache/src/lib.rs
+++ b/http-cache/src/lib.rs
@@ -530,7 +530,11 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                             policy,
                         )
                         .await?;
-                    res.set_cache_status_header(HitOrMiss::MISS)?;
+                    if cond_res.status == 304 {
+                        res.set_cache_status_header(HitOrMiss::HIT)?;
+                    } else {
+                        res.set_cache_status_header(HitOrMiss::MISS)?;
+                    }
                     res.set_cache_lookup_status_header(HitOrMiss::HIT)?;
                     Ok(res)
                 } else {

--- a/http-cache/src/lib.rs
+++ b/http-cache/src/lib.rs
@@ -460,7 +460,9 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                 )
                 .await?)
         } else if !middleware.is_method_get_head() {
-            self.manager.delete("GET", &middleware.url()?).await?;
+            if self.manager.get("GET", &middleware.url()?).await?.is_some() {
+                self.manager.delete("GET", &middleware.url()?).await?;
+            }
             Ok(res)
         } else {
             Ok(res)
@@ -504,7 +506,7 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                     );
                     cached_res.set_cache_status_header(HitOrMiss::HIT)?;
                     Ok(cached_res)
-                } else if cond_res.status == 304 {
+                } else if cond_res.status == 304 || cond_res.status == 200 {
                     let after_res = policy.after_response(
                         &middleware.parts()?,
                         &cond_res.parts()?,

--- a/http-cache/src/lib.rs
+++ b/http-cache/src/lib.rs
@@ -373,6 +373,7 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
             .await?
         {
             let (mut res, policy) = store;
+            res.set_cache_lookup_status_header(HitOrMiss::HIT)?;
             let res_url = res.url.clone();
             if let Some(warning_code) = res.warning_code() {
                 // https://tools.ietf.org/html/rfc7234#section-4.3.4

--- a/http-cache/src/lib.rs
+++ b/http-cache/src/lib.rs
@@ -29,7 +29,7 @@ mod error;
 mod managers;
 
 use std::{
-    collections::HashMap, convert::TryFrom, str::FromStr, time::SystemTime,
+    collections::HashMap, convert::TryFrom, fmt, str::FromStr, time::SystemTime,
 };
 
 use http::{header::CACHE_CONTROL, request, response, StatusCode};
@@ -49,6 +49,31 @@ pub use managers::moka::MokaManager;
 #[cfg(feature = "manager-moka")]
 #[cfg_attr(docsrs, doc(cfg(feature = "manager-moka")))]
 pub use moka::future::{Cache as MokaCache, CacheBuilder as MokaCacheBuilder};
+
+// Custom headers used to indicate cache status (hit or miss)
+/// `X-Cache` header: Did this proxy serve the result from cache (HIT for yes, MISS for no)
+pub const XCACHE: &str = "X-Cache";
+/// `X-Cache-Lookup` header: Did the proxy have a cacheable response to the request (HIT for yes, MISS for no)
+pub const XCACHELOOKUP: &str = "X-Cache-Lookup";
+
+/// Represents a basic cache status
+/// Used in the custom headers `X-Cache` and `X-Cache-Lookup`
+#[derive(Debug, Copy, Clone)]
+pub enum HitOrMiss {
+    /// Yes, there was a hit
+    HIT,
+    /// No, there was no hit
+    MISS,
+}
+
+impl fmt::Display for HitOrMiss {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            HitOrMiss::HIT => write!(f, "HIT"),
+            HitOrMiss::MISS => write!(f, "MISS"),
+        }
+    }
+}
 
 /// Represents an HTTP version
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
@@ -156,6 +181,25 @@ impl HttpResponse {
         } else {
             false
         }
+    }
+
+    /// Adds the custom `X-Cache` header to the response
+    pub fn set_cache_status_header(
+        &mut self,
+        cache_status: HitOrMiss,
+    ) -> Result<()> {
+        self.headers.insert(XCACHE.to_string(), cache_status.to_string());
+        Ok(())
+    }
+
+    /// Adds the custom `X-Cache-Lookup` header to the response
+    pub fn set_cache_lookup_status_header(
+        &mut self,
+        lookup_status: HitOrMiss,
+    ) -> Result<()> {
+        self.headers
+            .insert(XCACHELOOKUP.to_string(), lookup_status.to_string());
+        Ok(())
     }
 }
 
@@ -321,12 +365,16 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
             && self.mode != CacheMode::NoStore
             && self.mode != CacheMode::Reload;
         if !is_cacheable {
-            return middleware.remote_fetch().await;
+            let mut res = middleware.remote_fetch().await?;
+            res.set_cache_status_header(HitOrMiss::MISS)?;
+            res.set_cache_lookup_status_header(HitOrMiss::MISS)?;
+            return Ok(res);
         }
         if let Some(store) =
             self.manager.get(&middleware.method()?, &middleware.url()?).await?
         {
             let (mut res, policy) = store;
+            res.set_cache_lookup_status_header(HitOrMiss::HIT)?;
             let res_url = res.url.clone();
             if let Some(warning_code) = res.warning_code() {
                 // https://tools.ietf.org/html/rfc7234#section-4.3.4
@@ -359,6 +407,7 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                     // the rest of the network for a period of time.
                     // (https://tools.ietf.org/html/rfc2616#section-14.46)
                     res.add_warning(res_url, 112, "Disconnected operation");
+                    res.set_cache_status_header(HitOrMiss::HIT)?;
                     Ok(res)
                 }
                 _ => self.remote_fetch(&mut middleware).await,
@@ -367,15 +416,23 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
             match self.mode {
                 CacheMode::OnlyIfCached => {
                     // ENOTCACHED
-                    Ok(HttpResponse {
+                    let mut res = HttpResponse {
                         body: b"GatewayTimeout".to_vec(),
                         headers: Default::default(),
                         status: 504,
                         url: middleware.url()?,
                         version: HttpVersion::Http11,
-                    })
+                    };
+                    res.set_cache_status_header(HitOrMiss::MISS)?;
+                    res.set_cache_lookup_status_header(HitOrMiss::MISS)?;
+                    Ok(res)
                 }
-                _ => self.remote_fetch(&mut middleware).await,
+                _ => {
+                    let mut res = self.remote_fetch(&mut middleware).await?;
+                    res.set_cache_status_header(HitOrMiss::MISS)?;
+                    res.set_cache_lookup_status_header(HitOrMiss::MISS)?;
+                    Ok(res)
+                }
             }
         }
     }
@@ -384,7 +441,9 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
         &self,
         middleware: &mut impl Middleware,
     ) -> Result<HttpResponse> {
-        let res = middleware.remote_fetch().await?;
+        let mut res = middleware.remote_fetch().await?;
+        res.set_cache_status_header(HitOrMiss::MISS)?;
+        res.set_cache_lookup_status_header(HitOrMiss::MISS)?;
         let policy = match self.options {
             Some(options) => middleware.policy_with_options(&res, options)?,
             None => middleware.policy(&res)?,
@@ -420,6 +479,7 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
         match before_req {
             BeforeRequest::Fresh(parts) => {
                 cached_res.update_headers(parts)?;
+                cached_res.set_cache_status_header(HitOrMiss::HIT)?;
                 return Ok(cached_res);
             }
             BeforeRequest::Stale { request: parts, matches } => {
@@ -443,6 +503,7 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                         111,
                         "Revalidation failed",
                     );
+                    cached_res.set_cache_status_header(HitOrMiss::HIT)?;
                     Ok(cached_res)
                 } else if cond_res.status == 304 {
                     let after_res = policy.after_response(
@@ -457,7 +518,7 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                             cached_res.update_headers(parts)?;
                         }
                     }
-                    let res = self
+                    let mut res = self
                         .manager
                         .put(
                             &middleware.method()?,
@@ -466,8 +527,10 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                             policy,
                         )
                         .await?;
+                    res.set_cache_status_header(HitOrMiss::MISS)?;
                     Ok(res)
                 } else {
+                    cached_res.set_cache_status_header(HitOrMiss::HIT)?;
                     Ok(cached_res)
                 }
             }
@@ -481,6 +544,7 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                     //   due to an inability to reach the server.
                     // (https://tools.ietf.org/html/rfc2616#section-14.46)
                     cached_res.add_warning(req_url, 111, "Revalidation failed");
+                    cached_res.set_cache_status_header(HitOrMiss::HIT)?;
                     Ok(cached_res)
                 }
             }

--- a/http-cache/src/lib.rs
+++ b/http-cache/src/lib.rs
@@ -399,7 +399,10 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                 }
                 CacheMode::NoCache => {
                     middleware.set_no_cache()?;
-                    self.conditional_fetch(middleware, res, policy).await
+                    let mut res = self.remote_fetch(&mut middleware).await?;
+                    res.set_cache_status_header(HitOrMiss::MISS)?;
+                    res.set_cache_lookup_status_header(HitOrMiss::HIT)?;
+                    Ok(res)
                 }
                 CacheMode::ForceCache | CacheMode::OnlyIfCached => {
                     //   112 Disconnected operation

--- a/http-cache/src/lib.rs
+++ b/http-cache/src/lib.rs
@@ -51,13 +51,13 @@ pub use managers::moka::MokaManager;
 pub use moka::future::{Cache as MokaCache, CacheBuilder as MokaCacheBuilder};
 
 // Custom headers used to indicate cache status (hit or miss)
-/// `X-Cache` header: Did this proxy serve the result from cache (HIT for yes, MISS for no)
-pub const XCACHE: &str = "X-Cache";
-/// `X-Cache-Lookup` header: Did the proxy have a cacheable response to the request (HIT for yes, MISS for no)
-pub const XCACHELOOKUP: &str = "X-Cache-Lookup";
+/// `x-cache` header: Did this proxy serve the result from cache (HIT for yes, MISS for no)
+pub const XCACHE: &str = "x-cache";
+/// `x-cache-lookup` header: Did the proxy have a cacheable response to the request (HIT for yes, MISS for no)
+pub const XCACHELOOKUP: &str = "x-cache-lookup";
 
 /// Represents a basic cache status
-/// Used in the custom headers `X-Cache` and `X-Cache-Lookup`
+/// Used in the custom headers `x-cache` and `x-cache-lookup`
 #[derive(Debug, Copy, Clone)]
 pub enum HitOrMiss {
     /// Yes, there was a hit
@@ -183,7 +183,7 @@ impl HttpResponse {
         }
     }
 
-    /// Adds the custom `X-Cache` header to the response
+    /// Adds the custom `x-cache` header to the response
     pub fn set_cache_status_header(
         &mut self,
         cache_status: HitOrMiss,
@@ -192,7 +192,7 @@ impl HttpResponse {
         Ok(())
     }
 
-    /// Adds the custom `X-Cache-Lookup` header to the response
+    /// Adds the custom `x-cache-lookup` header to the response
     pub fn set_cache_lookup_status_header(
         &mut self,
         lookup_status: HitOrMiss,

--- a/http-cache/src/lib.rs
+++ b/http-cache/src/lib.rs
@@ -460,8 +460,9 @@ impl<T: CacheManager + Send + Sync + 'static> HttpCache<T> {
                 )
                 .await?)
         } else if !middleware.is_method_get_head() {
-            if self.manager.get("GET", &middleware.url()?).await?.is_some() {
-                self.manager.delete("GET", &middleware.url()?).await?;
+            match self.manager.delete("GET", &middleware.url()?).await {
+                Ok(()) => {}
+                Err(_e) => {}
             }
             Ok(res)
         } else {


### PR DESCRIPTION
- Adds `x-cache` and `x-cache-lookup` headers for cache hit/miss info
- Forces request method to uppercase in cache keys (breaking change)
- Extends several existing tests and adds new tests to help verify functionality
- Fixes issues when a conditional response has a 200 status, including updated response on revalidation and a response with a no-cache directive for example
- Fixes issue related to deleting an existing cache record on a non GET/HEAD method request to a previously cached resource 