### PR TITLE
Bump Moka to 0.9

### DIFF
--- a/http-cache/Cargo.toml
+++ b/http-cache/Cargo.toml
@@ -24,7 +24,7 @@ http-cache-semantics = "1.0.1"
 http-types = { version = "2.12.0", default-features = false, optional = true }
 httpdate = "1.0.2"
 miette = "4.7.1"
-moka = { version = "0.8.5", features = ["future"], optional = true }
+moka = { version = "0.9.4", features = ["future"], optional = true }
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0.31"
 url = { version = "2.2.2", features = ["serde"] }


### PR DESCRIPTION
This bumps Moka to 0.9. All tests are still passing and no further changes were needed.