### PR TITLE
Update `reqwest-middleware` dependency to v0.2.0

### DIFF
--- a/http-cache-reqwest/Cargo.toml
+++ b/http-cache-reqwest/Cargo.toml
@@ -19,7 +19,7 @@ async-trait = "0.1.58"
 http = "0.2.8"
 http-cache-semantics = "1.0.1"
 reqwest = { version = "0.11.12", default-features = false }
-reqwest-middleware = "0.1.6"
+reqwest-middleware = "0.2.0"
 serde = { version = "1.0.147", features = ["derive"] }
 task-local-extensions = "0.1.3"
 url = { version = "2.3.1", features = ["serde"] }


### PR DESCRIPTION
TrueLayer recently released a new minor version of `reqwest-middleware`. This PR updates `http-cache-reqwest` to be compatible with that new release :)

see https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md#020---2022-11-15