### PR TITLE
Disable default backend features in the client libraries

### DIFF
--- a/http-cache-reqwest/Cargo.toml
+++ b/http-cache-reqwest/Cargo.toml
@@ -27,6 +27,7 @@ url = { version = "2.3.1", features = ["serde"] }
 [dependencies.http-cache]
 path = "../http-cache"
 version = "0.9.2"
+default-features = false
 
 [dev-dependencies]
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }

--- a/http-cache-surf/Cargo.toml
+++ b/http-cache-surf/Cargo.toml
@@ -26,6 +26,7 @@ url = { version = "2.3.1", features = ["serde"] }
 [dependencies.http-cache]
 path = "../http-cache"
 version = "0.9.2"
+default-features = false
 features = ["with-http-types"]
 
 [dev-dependencies]


### PR DESCRIPTION
`http-cache-reqwest` and `http-cache-surf` both depend on `http-cache`, but neither disable the default features. This makes it impossible to not depend on `cacache`, even if `moka` is used as a manager. I think both client middleware libraries should have `default-features = false` set for the `http-cache` dependency.