### PR TITLE
Add initial implementation of custom cache key

### DIFF
--- a/http-cache-reqwest/src/lib.rs
+++ b/http-cache-reqwest/src/lib.rs
@@ -46,9 +46,9 @@ use std::{
     time::SystemTime,
 };
 
+pub use http::request::Parts;
 use http::{
     header::{HeaderName, CACHE_CONTROL},
-    request::Parts,
     HeaderValue, Method,
 };
 use http_cache::{CacheManager, Middleware, Result};
@@ -58,7 +58,9 @@ use reqwest_middleware::{Error, Next};
 use task_local_extensions::Extensions;
 use url::Url;
 
-pub use http_cache::{CacheMode, CacheOptions, HttpCache, HttpResponse};
+pub use http_cache::{
+    CacheMode, CacheOptions, HttpCache, HttpCacheOptions, HttpResponse,
+};
 
 #[cfg(feature = "manager-cacache")]
 #[cfg_attr(docsrs, doc(cfg(feature = "manager-cacache")))]

--- a/http-cache-reqwest/src/lib.rs
+++ b/http-cache-reqwest/src/lib.rs
@@ -15,7 +15,7 @@
 //! ```no_run
 //! use reqwest::Client;
 //! use reqwest_middleware::{ClientBuilder, Result};
-//! use http_cache_reqwest::{Cache, CacheMode, CACacheManager, HttpCache};
+//! use http_cache_reqwest::{Cache, CacheMode, CACacheManager, HttpCache, HttpCacheOptions};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
@@ -23,7 +23,7 @@
 //!         .with(Cache(HttpCache {
 //!             mode: CacheMode::Default,
 //!             manager: CACacheManager::default(),
-//!             options: None,
+//!             options: HttpCacheOptions::default(),
 //!         }))
 //!         .build();
 //!     client

--- a/http-cache-surf/src/lib.rs
+++ b/http-cache-surf/src/lib.rs
@@ -13,7 +13,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! The surf middleware implementation for http-cache.
 //! ```no_run
-//! use http_cache_surf::{Cache, CacheMode, CACacheManager, HttpCache};
+//! use http_cache_surf::{Cache, CacheMode, CACacheManager, HttpCache, HttpCacheOptions};
 //!
 //! #[async_std::main]
 //! async fn main() -> surf::Result<()> {
@@ -22,7 +22,7 @@
 //!         .with(Cache(HttpCache {
 //!             mode: CacheMode::Default,
 //!             manager: CACacheManager::default(),
-//!             options: None,
+//!             options: HttpCacheOptions::default(),
 //!         }))
 //!         .send(req)
 //!         .await?;

--- a/http-cache-surf/src/lib.rs
+++ b/http-cache-surf/src/lib.rs
@@ -36,14 +36,17 @@ use std::{
     collections::HashMap, convert::TryInto, str::FromStr, time::SystemTime,
 };
 
-use http::{header::CACHE_CONTROL, request, request::Parts};
+pub use http::request::Parts;
+use http::{header::CACHE_CONTROL, request};
 use http_cache::{BadHeader, BoxError, CacheManager, Middleware, Result};
 use http_cache_semantics::CachePolicy;
 use http_types::{headers::HeaderValue, Method, Response, StatusCode, Version};
 use surf::{middleware::Next, Client, Request};
 use url::Url;
 
-pub use http_cache::{CacheMode, CacheOptions, HttpCache, HttpResponse};
+pub use http_cache::{
+    CacheMode, CacheOptions, HttpCache, HttpCacheOptions, HttpResponse,
+};
 
 #[cfg(feature = "manager-cacache")]
 #[cfg_attr(docsrs, doc(cfg(feature = "manager-cacache")))]

--- a/http-cache-tests/src/lib.rs
+++ b/http-cache-tests/src/lib.rs
@@ -160,17 +160,23 @@ mod http_cache_tests {
                 .status(200)
                 .body(TEST_BODY.to_vec())?;
             let policy = CachePolicy::new(&req, &res);
-            manager.put(GET, &url, http_res.clone(), policy.clone()).await?;
-            let data = manager.get(GET, &url).await?;
+            manager
+                .put(
+                    format!("{}:{}", GET, &url),
+                    http_res.clone(),
+                    policy.clone(),
+                )
+                .await?;
+            let data = manager.get(&format!("{}:{}", GET, &url)).await?;
             assert!(data.is_some());
             assert_eq!(data.unwrap().0.body, TEST_BODY);
-            manager.delete(GET, &url).await?;
-            let data = manager.get(GET, &url).await?;
+            manager.delete(&format!("{}:{}", GET, &url)).await?;
+            let data = manager.get(&format!("{}:{}", GET, &url)).await?;
             assert!(data.is_none());
 
-            manager.put(GET, &url, http_res, policy).await?;
+            manager.put(format!("{}:{}", GET, &url), http_res, policy).await?;
             manager.clear().await?;
-            let data = manager.get(GET, &url).await?;
+            let data = manager.get(&format!("{}:{}", GET, &url)).await?;
             assert!(data.is_none());
             Ok(())
         }
@@ -196,17 +202,23 @@ mod http_cache_tests {
                 .status(200)
                 .body(TEST_BODY.to_vec())?;
             let policy = CachePolicy::new(&req, &res);
-            manager.put(GET, &url, http_res.clone(), policy.clone()).await?;
-            let data = manager.get(GET, &url).await?;
+            manager
+                .put(
+                    format!("{}:{}", GET, &url),
+                    http_res.clone(),
+                    policy.clone(),
+                )
+                .await?;
+            let data = manager.get(&format!("{}:{}", GET, &url)).await?;
             assert!(data.is_some());
             assert_eq!(data.unwrap().0.body, TEST_BODY);
-            manager.delete(GET, &url).await?;
-            let data = manager.get(GET, &url).await?;
+            manager.delete(&format!("{}:{}", GET, &url)).await?;
+            let data = manager.get(&format!("{}:{}", GET, &url)).await?;
             assert!(data.is_none());
 
-            manager.put(GET, &url, http_res, policy).await?;
+            manager.put(format!("{}:{}", GET, &url), http_res, policy).await?;
             manager.clear().await?;
-            let data = manager.get(GET, &url).await?;
+            let data = manager.get(&format!("{}:{}", GET, &url)).await?;
             assert!(data.is_none());
             Ok(())
         }

--- a/http-cache/src/managers/cacache.rs
+++ b/http-cache/src/managers/cacache.rs
@@ -4,7 +4,6 @@ use crate::{CacheManager, HttpResponse, Result};
 
 use http_cache_semantics::CachePolicy;
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 /// Implements [`CacheManager`] with [`cacache`](https://github.com/zkat/cacache-rs) as the backend.
 #[cfg_attr(docsrs, doc(cfg(feature = "manager-cacache")))]
@@ -26,10 +25,6 @@ struct Store {
     policy: CachePolicy,
 }
 
-fn req_key(method: &str, url: &Url) -> String {
-    format!("{method}:{url}")
-}
-
 #[allow(dead_code)]
 impl CACacheManager {
     /// Clears out the entire cache.
@@ -43,33 +38,30 @@ impl CACacheManager {
 impl CacheManager for CACacheManager {
     async fn get(
         &self,
-        method: &str,
-        url: &Url,
+        cache_key: &str,
     ) -> Result<Option<(HttpResponse, CachePolicy)>> {
-        let store: Store =
-            match cacache::read(&self.path, &req_key(method, url)).await {
-                Ok(d) => bincode::deserialize(&d)?,
-                Err(_e) => {
-                    return Ok(None);
-                }
-            };
+        let store: Store = match cacache::read(&self.path, cache_key).await {
+            Ok(d) => bincode::deserialize(&d)?,
+            Err(_e) => {
+                return Ok(None);
+            }
+        };
         Ok(Some((store.response, store.policy)))
     }
 
     async fn put(
         &self,
-        method: &str,
-        url: &Url,
+        cache_key: String,
         response: HttpResponse,
         policy: CachePolicy,
     ) -> Result<HttpResponse> {
         let data = Store { response: response.clone(), policy };
         let bytes = bincode::serialize(&data)?;
-        cacache::write(&self.path, &req_key(method, url), bytes).await?;
+        cacache::write(&self.path, cache_key, bytes).await?;
         Ok(response)
     }
 
-    async fn delete(&self, method: &str, url: &Url) -> Result<()> {
-        Ok(cacache::remove(&self.path, &req_key(method, url)).await?)
+    async fn delete(&self, cache_key: &str) -> Result<()> {
+        Ok(cacache::remove(&self.path, cache_key).await?)
     }
 }


### PR DESCRIPTION
Initail implementation for #25

Some things of note:
- The `cache_key` closure is wrapped in an `Arc` to allow the `HttpCache` struct to be cloned.
- The `CacheManager` function signatures were changed to take just the cache key.
- An override cache key parameter was added to the `HttpCacheOptions.create_cache_key` function to not change the behaviour for `is_get_head`.
- All tests are passing and a test was added to the `client_reqwest` tests called `custom_cache_key`.