### PR TITLE
fix `cache_mode_fn` consistency

### DIFF
--- a/http-cache-reqwest/src/lib.rs
+++ b/http-cache-reqwest/src/lib.rs
@@ -174,7 +174,7 @@ fn convert_response(response: HttpResponse) -> anyhow::Result<Response> {
     let mut ret_res = http::Response::builder()
         .status(response.status)
         .url(response.url)
-        .version(response.version.try_into()?)
+        .version(response.version.into())
         .body(response.body)?;
     for header in response.headers {
         ret_res.headers_mut().insert(

--- a/http-cache-reqwest/src/test.rs
+++ b/http-cache-reqwest/src/test.rs
@@ -182,7 +182,7 @@ async fn custom_cache_mode_fn() -> Result<()> {
     // Construct reqwest client with cache defaults and custom cache mode
     let client = ClientBuilder::new(Client::new())
         .with(Cache(HttpCache {
-            mode: CacheMode::Default,
+            mode: CacheMode::NoStore,
             manager: manager.clone(),
             options: HttpCacheOptions {
                 cache_key: None,

--- a/http-cache-surf/src/lib.rs
+++ b/http-cache-surf/src/lib.rs
@@ -140,7 +140,13 @@ impl Middleware for SurfMiddleware<'_> {
         let status = res.status().into();
         let version = res.version().unwrap_or(Version::Http1_1);
         let body: Vec<u8> = res.body_bytes().await?;
-        Ok(HttpResponse { body, headers, status, url, version: version.into() })
+        Ok(HttpResponse {
+            body,
+            headers,
+            status,
+            url,
+            version: version.try_into()?,
+        })
     }
 }
 
@@ -171,7 +177,7 @@ impl<T: CacheManager> surf::middleware::Middleware for Cache<T> {
                 converted.insert_header(header.0.as_str(), val);
             }
             converted.set_status(res.status.try_into()?);
-            converted.set_version(Some(res.version.try_into()?));
+            converted.set_version(Some(res.version.into()));
             converted.set_body(res.body);
             Ok(surf::Response::from(converted))
         } else {

--- a/http-cache-surf/src/lib.rs
+++ b/http-cache-surf/src/lib.rs
@@ -140,13 +140,7 @@ impl Middleware for SurfMiddleware<'_> {
         let status = res.status().into();
         let version = res.version().unwrap_or(Version::Http1_1);
         let body: Vec<u8> = res.body_bytes().await?;
-        Ok(HttpResponse {
-            body,
-            headers,
-            status,
-            url,
-            version: version.try_into()?,
-        })
+        Ok(HttpResponse { body, headers, status, url, version: version.into() })
     }
 }
 

--- a/http-cache/src/lib.rs
+++ b/http-cache/src/lib.rs
@@ -432,11 +432,7 @@ impl<T: CacheManager> HttpCache<T> {
         &self,
         middleware: &impl Middleware,
     ) -> Result<bool> {
-        let mode = if let Some(cache_mode_fn) = &self.options.cache_mode_fn {
-            cache_mode_fn(&middleware.parts()?)
-        } else {
-            self.mode
-        };
+        let mode = self.cache_mode(middleware)?;
 
         Ok(mode == CacheMode::IgnoreRules
             || middleware.is_method_get_head()
@@ -516,7 +512,7 @@ impl<T: CacheManager> HttpCache<T> {
                 }
             }
 
-            match self.mode {
+            match self.cache_mode(&middleware)? {
                 CacheMode::Default => {
                     self.conditional_fetch(middleware, res, policy).await
                 }
@@ -544,7 +540,7 @@ impl<T: CacheManager> HttpCache<T> {
                 _ => self.remote_fetch(&mut middleware).await,
             }
         } else {
-            match self.mode {
+            match self.cache_mode(&middleware)? {
                 CacheMode::OnlyIfCached => {
                     // ENOTCACHED
                     let mut res = HttpResponse {
@@ -563,6 +559,14 @@ impl<T: CacheManager> HttpCache<T> {
         }
     }
 
+    fn cache_mode(&self, middleware: &impl Middleware) -> Result<CacheMode> {
+        Ok(if let Some(cache_mode_fn) = &self.options.cache_mode_fn {
+            cache_mode_fn(&middleware.parts()?)
+        } else {
+            self.mode
+        })
+    }
+
     async fn remote_fetch(
         &self,
         middleware: &mut impl Middleware,
@@ -575,12 +579,13 @@ impl<T: CacheManager> HttpCache<T> {
             None => middleware.policy(&res)?,
         };
         let is_get_head = middleware.is_method_get_head();
+        let mode = self.cache_mode(middleware)?;
         let mut is_cacheable = is_get_head
-            && self.mode != CacheMode::NoStore
-            && self.mode != CacheMode::Reload
+            && mode != CacheMode::NoStore
+            && mode != CacheMode::Reload
             && res.status == 200
             && policy.is_storable();
-        if self.mode == CacheMode::IgnoreRules && res.status == 200 {
+        if mode == CacheMode::IgnoreRules && res.status == 200 {
             is_cacheable = true;
         }
         if is_cacheable {


### PR DESCRIPTION
`cache_mode_fn` was added to `HttpCacheOptions` to allow different cache modes to be used for different requests. However, `cache_mode_fn` was only consulted when determining if a request could be satisfied from the cache, not when determining whether to use an existing cached value or whether to cache a fresh value. The test was incorrectly passing because `cache_mode_fn` was setting the mode equal to the same value that it would have been otherwise.

This PR makes all code paths use `cache_mode_fn` consistently and fixes the `cache_mode_fn` test to rely on `cache_mode_fn` working.