### PR TITLE
allow mode override by reqwest-middleware extension

### DIFF
--- a/http-cache-reqwest/src/lib.rs
+++ b/http-cache-reqwest/src/lib.rs
@@ -33,6 +33,18 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## Overriding the cache mode
+//!
+//! The cache mode can be overridden on a per-request basis by making use of the
+//! `reqwest-middleware` extensions system.
+//!
+//! ```no_run
+//! client.get("https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching")
+//!     .with_extension(CacheMode::OnlyIfCached)
+//!     .send()
+//!     .await?;
+//! ```
 mod error;
 
 use anyhow::anyhow;
@@ -93,6 +105,9 @@ fn clone_req(request: &Request) -> std::result::Result<Request, Error> {
 
 #[async_trait::async_trait]
 impl Middleware for ReqwestMiddleware<'_> {
+    fn overridden_cache_mode(&self) -> Option<CacheMode> {
+        self.extensions.get().cloned()
+    }
     fn is_method_get_head(&self) -> bool {
         self.req.method() == Method::GET || self.req.method() == Method::HEAD
     }

--- a/http-cache-reqwest/src/test.rs
+++ b/http-cache-reqwest/src/test.rs
@@ -218,6 +218,46 @@ async fn custom_cache_mode_fn() -> Result<()> {
 }
 
 #[tokio::test]
+async fn override_cache_mode() -> Result<()> {
+    let mock_server = MockServer::start().await;
+    let m = build_mock(CACHEABLE_PUBLIC, TEST_BODY, 200, 2);
+    let _mock_guard = mock_server.register_as_scoped(m).await;
+    let url = format!("{}/test.css", &mock_server.uri());
+    let manager = MokaManager::default();
+
+    // Construct reqwest client with cache defaults and custom cache mode
+    let client = ClientBuilder::new(Client::new())
+        .with(Cache(HttpCache {
+            mode: CacheMode::Default,
+            manager: manager.clone(),
+            options: HttpCacheOptions {
+                cache_key: None,
+                cache_options: None,
+                cache_mode_fn: None,
+                cache_bust: None,
+            },
+        }))
+        .build();
+
+    // Remote request and should cache
+    client.get(url.clone()).send().await?;
+
+    // Try to load cached object
+    let data = manager.get(&format!("{}:{}", GET, &Url::parse(&url)?)).await?;
+    assert!(data.is_some());
+
+    let url = format!("{}/", &mock_server.uri());
+    // To verify our endpoint receives the request rather than a cache hit
+    client.get(url.clone()).with_extension(CacheMode::NoStore).send().await?;
+
+    // Check no cache object was created
+    let data = manager.get(&format!("{}:{}", GET, &Url::parse(&url)?)).await?;
+    assert!(data.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn cache_bust() -> Result<()> {
     let mock_server = MockServer::start().await;
     let m = build_mock(CACHEABLE_PUBLIC, TEST_BODY, 200, 2);


### PR DESCRIPTION
This PR allows users of `http-cache-reqwest` to override the cache mode on a per-request basis using `reqwest-middleware`'s extension mechanism. For `cache_mode_fn`, the request parts need to have some recognizable characteristic that is known ahead of time, or the `cache_mode_fn` implementation needs to have some shared mutable state that allows recognizable requests to be registered on the fly. With request extensions, the caller can simply specify something like `.with_extension(CacheMode::Reload)` when building the request and just that request will be affected, even if it has the exact same parts as another request.

Other middleware implementations can implement a similar feature by providing an implementation for the new `overridden_cache_mode` function, but I don't know of an equivalent capability for surf so I didn't implement this feature there.