### PR TITLE
Use http-1.0.0 for http-cache-tower

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "http-cache-surf",
     "http-cache-quickcache",
     "http-cache-darkbird",
-    "http-cache-mokadeser"
+    "http-cache-mokadeser",
+    "http-cache-tower"
 ]

--- a/http-cache-darkbird/Cargo.toml
+++ b/http-cache-darkbird/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.67.1"
 [dependencies]
 async-trait = "0.1.72"
 darkbird = "6.1.8"
-http-cache-semantics = "1.0.1"
+http-cache-semantics = "2.0.1"
 serde = { version = "1.0.178", features = ["derive"] }
 thiserror = "1.0.44"
 
@@ -28,7 +28,7 @@ version = "0.18.0"
 default-features = false
 
 [dev-dependencies]
-http = "0.2.9"
+http = "1.0.0"
 reqwest = { version = "0.11.18", default-features = false }
 reqwest-middleware = "0.2.2"
 tokio = { version = "1.29.1", features = [ "macros", "rt", "rt-multi-thread" ] }

--- a/http-cache-mokadeser/Cargo.toml
+++ b/http-cache-mokadeser/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.67.1"
 
 [dependencies]
 async-trait = "0.1.72"
-http-cache-semantics = "1.0.1"
+http-cache-semantics = "2.0.1"
 moka = { version = "0.12.0", features = ["future"]}
 
 [dependencies.http-cache]
@@ -27,7 +27,7 @@ default-features = false
 features = ["bincode"]
 
 [dev-dependencies]
-http = "0.2.9"
+http = "1.0.0"
 reqwest = { version = "0.11.18", default-features = false }
 reqwest-middleware = "0.2.2"
 tokio = { version = "1.29.1", features = [ "macros", "rt", "rt-multi-thread" ] }

--- a/http-cache-quickcache/Cargo.toml
+++ b/http-cache-quickcache/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.67.1"
 [dependencies]
 async-trait = "0.1.72"
 bincode = "1.3.3"
-http-cache-semantics = "1.0.1"
+http-cache-semantics = "2.0.1"
 serde = { version = "1.0.178", features = ["derive"] }
 url = { version = "2.4.0", features = ["serde"] }
 quick_cache = "0.4.0"
@@ -30,7 +30,7 @@ default-features = false
 features = ["bincode"]
 
 [dev-dependencies]
-http = "0.2.9"
+http = "1.0.0"
 reqwest = { version = "0.11.18", default-features = false }
 reqwest-middleware = "0.2.2"
 tokio = { version = "1.29.1", features = [ "macros", "rt", "rt-multi-thread" ] }

--- a/http-cache-reqwest/Cargo.toml
+++ b/http-cache-reqwest/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 anyhow = "1.0.72"
 async-trait = "0.1.72"
 http = "0.2.9"
-http-cache-semantics = "1.0.1"
+http-cache-semantics = "2.0.1"
 reqwest = { version = "0.11.18", default-features = false }
 reqwest-middleware = "0.2.2"
 serde = { version = "1.0.178", features = ["derive"] }

--- a/http-cache-surf/Cargo.toml
+++ b/http-cache-surf/Cargo.toml
@@ -17,8 +17,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.72"
 async-trait = "0.1.72"
-http = "0.2.9"
-http-cache-semantics = "1.0.1"
+http = "1.0.0"
+http-cache-semantics = "2.0.1"
 http-types = "2.12.0"
 serde = { version = "1.0.178", features = ["derive"] }
 surf = { version = "2.3.2", default-features = false }

--- a/http-cache-tower/Cargo.toml
+++ b/http-cache-tower/Cargo.toml
@@ -21,7 +21,7 @@ http-body = "1.0.0"
 pin-project-lite = "0.2.9"
 tower-layer = "0.3.1"
 tower-service = "0.3.2"
-http-cache-semantics = "1.0.1"
+http-cache-semantics = "2.0.1"
 serde = { version = "1.0.144", features = ["derive"] }
 url = { version = "2.2.2", features = ["serde"] }
 tower = { version = "0.4.13", features = ["util"] }

--- a/http-cache-tower/Cargo.toml
+++ b/http-cache-tower/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "http-cache-tower"
+version = "0.1.0"
+description = "http-cache middleware implementation for tower"
+authors = ["Christian Haynes <06chaynes@gmail.com>", "Kat Marchán <kzm@zkat.tech>"]
+repository = "https://github.com/06chaynes/http-cache.git"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+keywords = ["cache", "http", "middleware", "tower"]
+categories = [
+    "caching",
+    "web-programming::http-client"
+]
+edition = "2021"
+
+[dependencies]
+futures-core = "0.3.23"
+futures-util = { version = "0.3.23", default-features = false, features = [] }
+http = "1.0.0"
+http-body = "1.0.0"
+pin-project-lite = "0.2.9"
+tower-layer = "0.3.1"
+tower-service = "0.3.2"
+http-cache-semantics = "1.0.1"
+serde = { version = "1.0.144", features = ["derive"] }
+url = { version = "2.2.2", features = ["serde"] }
+tower = { version = "0.4.13", features = ["util"] }
+
+[dependencies.http-cache]
+path = "../http-cache"
+version = "0.18.0"
+
+[dev-dependencies]
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = ["manager-cacache"]
+manager-cacache = ["http-cache/manager-cacache"]
+manager-moka = ["http-cache/manager-moka"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/http-cache-tower/src/lib.rs
+++ b/http-cache-tower/src/lib.rs
@@ -1,0 +1,151 @@
+use futures_core::ready;
+use futures_util::future::Either;
+
+use std::{
+    convert::TryFrom,
+    convert::TryInto,
+    future::Future,
+    mem,
+    pin::Pin,
+    str,
+    str::FromStr,
+    task::{Context, Poll},
+};
+
+use http::{
+    header::{HeaderName, CACHE_CONTROL},
+    request, HeaderMap, HeaderValue, Method, Request, Response, StatusCode,
+    Uri, Version,
+};
+use http_body::Body;
+use http_cache::{BoxError, CacheManager, Result};
+use pin_project_lite::pin_project;
+use tower::util::Oneshot;
+use tower_layer::Layer;
+use tower_service::Service;
+
+pub use http_cache::{CacheMode, CacheOptions, HttpCache, HttpResponse};
+
+#[cfg(feature = "manager-cacache")]
+#[cfg_attr(docsrs, doc(cfg(feature = "manager-cacache")))]
+pub use http_cache::CACacheManager;
+
+#[cfg(feature = "manager-moka")]
+#[cfg_attr(docsrs, doc(cfg(feature = "manager-moka")))]
+pub use http_cache::{MokaCache, MokaCacheBuilder, MokaManager};
+
+/// Wrapper for [`HttpCache`]
+#[derive(Debug)]
+pub struct Cache<S, T: CacheManager> {
+    inner: S,
+    cache: HttpCache<T>,
+}
+
+impl<S, T> Cache<S, T>
+where
+    T: Clone + CacheManager,
+{
+    /// Create a new [`Cache`].
+    pub fn new(inner: S, cache: HttpCache<T>) -> Self {
+        Self { inner, cache }
+    }
+
+    /// Returns a new [`Layer`] that wraps services with a `Cache` middleware.
+    pub fn layer(&self) -> CacheLayer<T> {
+        CacheLayer::new(self.cache.clone())
+    }
+}
+
+/// [`Layer`] with a [`Service`] to cache responses.
+#[derive(Clone, Debug)]
+pub struct CacheLayer<T: CacheManager> {
+    cache: HttpCache<T>,
+}
+
+impl<T> CacheLayer<T>
+where
+    T: CacheManager,
+{
+    /// Create a new [`CacheLayer`].
+    pub fn new(cache: HttpCache<T>) -> Self {
+        Self { cache }
+    }
+}
+
+impl<S, T> Layer<S> for CacheLayer<T>
+where
+    S: Clone,
+    T: Clone + CacheManager,
+{
+    type Service = Cache<S, T>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Cache { inner, cache: self.cache.clone() }
+    }
+}
+
+impl<ReqBody, ResBody, S, T> Service<Request<ReqBody>> for Cache<S, T>
+where
+    S: Clone + Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ReqBody: Body + Clone,
+    T: Clone + CacheManager,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S, ReqBody, T>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let service = self.inner.clone();
+        let mut service = mem::replace(&mut self.inner, service);
+        ResponseFuture {
+            req: req.clone(),
+            future: Either::Left(service.call(req)),
+            service,
+            cache: self.cache.clone(),
+        }
+    }
+}
+
+pin_project! {
+    /// Response future for [`Cache`].
+    #[derive(Debug)]
+    pub struct ResponseFuture<S, B, T>
+    where
+        S: Service<Request<B>>,
+        T: CacheManager,
+    {
+        #[pin]
+        future: Either<S::Future, Oneshot<S, Request<B>>>,
+        service: S,
+        req: Request<B>,
+        cache: HttpCache<T>,
+    }
+}
+
+impl<S, ReqBody, ResBody, T> Future for ResponseFuture<S, ReqBody, T>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone,
+    ReqBody: Body + Clone,
+    T: CacheManager + Clone,
+{
+    type Output = std::result::Result<Response<ResBody>, S::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+        let request_parts = this.req.clone().into_parts().0;
+        // TODO: figure out how to run an async methods here
+        // let action = this
+        //     .cache
+        //     .before_request(&request_parts)
+        //     .await;
+        let res = ready!(this.future.as_mut().poll(cx)?);
+        Poll::Ready(Ok(res))
+    }
+}

--- a/http-cache/Cargo.toml
+++ b/http-cache/Cargo.toml
@@ -19,8 +19,8 @@ rust-version = "1.67.1"
 async-trait = "0.1.72"
 bincode = { version = "1.3.3", optional = true }
 cacache = { version = "12.0.0", default-features = false, features = ["mmap"], optional = true }
-http = "0.2.9"
-http-cache-semantics = "1.0.1"
+http = "1.0.0"
+http-cache-semantics = "2.0.1"
 http-types = { version = "2.12.0", default-features = false, optional = true }
 httpdate = "1.0.2"
 moka = { version = "0.12.0", features = ["future"], optional = true }
@@ -30,7 +30,6 @@ url = { version = "2.4.0", features = ["serde"] }
 [dev-dependencies]
 async-attributes = "1.1.2"
 async-std = { version = "1.12.0" }
-http-cache-semantics = "1.0.1"
 tokio = { version = "1.29.1", features = [ "macros", "rt", "rt-multi-thread" ] }
 
 [features]


### PR DESCRIPTION
WIP branch for updating the `refactor` branch to use `http-1.0.0`, per our discussion in https://github.com/06chaynes/http-cache/issues/4.

If accepting the `Clone` bound on `ReqBody` is acceptable, it simplifies the passing of the request to the future quite a lot.

If this looks promising to you, I can also try to tackle updating the future into a state-machine so that we can poll other futures inside of it. I know the `refactor` branch is quite far behind the `main` branch though, so if it makes more sense to work off of that one, let me know. I might need some pointers in terms of which methods need to be called inside the future since I'm not too familiar with `http-cache` internals.