### PR TITLE
Streaming HTTP body types

### DIFF
--- a/http-cache-reqwest/Cargo.toml
+++ b/http-cache-reqwest/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.95"
 async-trait = "0.1.85"
 http = "1.2.0"
 http-cache-semantics = "2.1.0"
-reqwest = { version = "0.12.12", default-features = false }
+reqwest = { version = "0.12.12", default-features = false, features = ["stream"] }
 reqwest-middleware = "0.4.0"
 serde = { version = "1.0.217", features = ["derive"] }
 url = { version = "2.5.4", features = ["serde"] }

--- a/http-cache/Cargo.toml
+++ b/http-cache/Cargo.toml
@@ -18,28 +18,34 @@ rust-version = "1.71.1"
 [dependencies]
 async-trait = "0.1.85"
 bincode = { version = "1.3.3", optional = true }
+bytes = "1.10.1"
 cacache = { version = "13.1.0", default-features = false, features = ["mmap"], optional = true }
-futures-lite = { version = "2.6.0", optional = true }
+futures = "0.3.31"
+futures-util = "0.3.31"
 http = "1.2.0"
+http-body = "1.0.1"
+http-body-util = "0.1.3"
 http-cache-semantics = "2.1.0"
 http-types = { version = "2.12.0", default-features = false, optional = true }
 httpdate = "1.0.3"
 moka = { version = "0.12.10", features = ["future"], optional = true }
 serde = { version = "1.0.217", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["io-util"], optional = true }
+tokio-util = { version = "0.7.14", features = ["io"], optional = true }
 url = { version = "2.5.4", features = ["serde"] }
 
 [dev-dependencies]
 async-attributes = "1.1.2"
 async-std = { version = "1.13.0" }
 http-cache-semantics = "2.1.0"
+tempfile = "3.19.1"
 tokio = { version = "1.43.0", features = [ "macros", "rt", "rt-multi-thread" ] }
 
 [features]
 default = ["manager-cacache", "cacache-async-std"]
 manager-cacache = ["cacache", "bincode"]
-cacache-tokio = ["cacache/tokio-runtime", "tokio"]
-cacache-async-std = ["cacache/async-std", "futures-lite"]
+cacache-tokio = ["cacache/tokio-runtime", "tokio", "tokio-util"]
+cacache-async-std = ["cacache/async-std"]
 manager-moka = ["moka", "bincode"]
 with-http-types = ["http-types"]
 

--- a/http-cache/Cargo.toml
+++ b/http-cache/Cargo.toml
@@ -19,12 +19,14 @@ rust-version = "1.71.1"
 async-trait = "0.1.85"
 bincode = { version = "1.3.3", optional = true }
 cacache = { version = "13.1.0", default-features = false, features = ["mmap"], optional = true }
+futures-lite = { version = "2.6.0", optional = true }
 http = "1.2.0"
 http-cache-semantics = "2.1.0"
 http-types = { version = "2.12.0", default-features = false, optional = true }
 httpdate = "1.0.3"
 moka = { version = "0.12.10", features = ["future"], optional = true }
 serde = { version = "1.0.217", features = ["derive"] }
+tokio = { version = "1", default-features = false, features = ["io-util"], optional = true }
 url = { version = "2.5.4", features = ["serde"] }
 
 [dev-dependencies]
@@ -36,8 +38,8 @@ tokio = { version = "1.43.0", features = [ "macros", "rt", "rt-multi-thread" ] }
 [features]
 default = ["manager-cacache", "cacache-async-std"]
 manager-cacache = ["cacache", "bincode"]
-cacache-tokio = ["cacache/tokio-runtime"]
-cacache-async-std = ["cacache/async-std"]
+cacache-tokio = ["cacache/tokio-runtime", "tokio"]
+cacache-async-std = ["cacache/async-std", "futures-lite"]
 manager-moka = ["moka", "bincode"]
 with-http-types = ["http-types"]
 

--- a/http-cache/src/managers/cacache.rs
+++ b/http-cache/src/managers/cacache.rs
@@ -1,9 +1,20 @@
 use std::path::PathBuf;
+use std::result::Result as StdResult;
 
-use crate::{CacheManager, HttpResponse, Parts, Result};
+use crate::{Body, CacheManager, HttpResponse, Parts, Result};
 
+use bytes::Bytes;
+use cacache::{Reader, Writer};
+use futures::{Stream, StreamExt};
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt, StreamBody};
 use http_cache_semantics::CachePolicy;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "cacache-async-std")]
+use futures::{AsyncReadExt, AsyncWriteExt};
+#[cfg(feature = "cacache-tokio")]
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Implements [`CacheManager`] with [`cacache`](https://github.com/zkat/cacache-rs) as the backend.
 #[cfg_attr(docsrs, doc(cfg(feature = "manager-cacache")))]
@@ -19,23 +30,21 @@ impl Default for CACacheManager {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-struct Store {
-    response: HttpResponse<Vec<u8>>,
-    policy: CachePolicy,
-}
-
 // Cache binary value layout:
-// [u32 - size of the NoBodyStore][NoBodyStore][response body bytes]
+// [u32 - size of the NoBodyStore][Store][response body bytes]
 // bincode works with pre-defined slice of bytes, so we need this u32 in front.
 
-// FIXME: this layout needs to be used for both CacheManager impls.
-// Otherwise user won't be able to use different impls with the same cache instance.
+#[derive(Debug, Deserialize, Serialize)]
+enum BodyKind {
+    Full,
+    Streaming,
+}
 
 #[derive(Debug, Deserialize, Serialize)]
-struct NoBodyStore {
+struct Store {
     parts: Parts,
     policy: CachePolicy,
+    body_kind: BodyKind,
 }
 
 #[allow(dead_code)]
@@ -47,92 +56,168 @@ impl CACacheManager {
     }
 }
 
+#[cfg(feature = "cacache-async-std")]
+mod cacache_stream {
+    use super::*;
+    use futures::AsyncRead;
+    use std::pin::Pin;
+    use std::task::Context;
+    use std::task::Poll;
+
+    // Some custom dummy implementation of Stream for cacache Reader.
+
+    const BUFSIZE: usize = 4096;
+
+    pub struct CACacheReaderStream {
+        reader: Reader,
+        buf: [u8; BUFSIZE],
+    }
+
+    impl CACacheReaderStream {
+        pub fn new(reader: Reader) -> Self {
+            Self { reader, buf: [0; BUFSIZE] }
+        }
+    }
+
+    impl Stream for CACacheReaderStream {
+        type Item = StdResult<http_body::Frame<Bytes>, std::io::Error>;
+
+        fn poll_next(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Self::Item>> {
+            let Self { reader, buf } = &mut *self;
+            let reader = Pin::new(reader);
+            match reader.poll_read(cx, buf) {
+                Poll::Ready(Ok(0)) => Poll::Ready(None),
+                Poll::Ready(Ok(n)) => {
+                    let bytes = Bytes::from(buf[..n].to_vec());
+                    let frame = http_body::Frame::data(bytes);
+                    Poll::Ready(Some(Ok(frame)))
+                }
+                Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+}
+
+#[cfg(feature = "cacache-tokio")]
+mod cacache_stream {
+    use super::*;
+    use tokio_util::io::ReaderStream;
+
+    pub struct CACacheReaderStream {
+        inner: ReaderStream<Reader>,
+    }
+
+    impl CACacheReaderStream {
+        pub fn new(reader: Reader) -> Self {
+            Self { inner: ReaderStream::new(reader) }
+        }
+    }
+
+    impl Stream for CACacheReaderStream {
+        type Item = StdResult<http_body::Frame<Bytes>, std::io::Error>;
+
+        fn poll_next(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            <ReaderStream<Reader> as Stream>::poll_next(
+                std::pin::Pin::new(&mut self.inner),
+                cx,
+            )
+            .map(|opt| opt.map(|res| res.map(http_body::Frame::data)))
+        }
+    }
+}
+
+use cacache_stream::CACacheReaderStream;
+
 #[async_trait::async_trait]
 impl CacheManager for CACacheManager {
     async fn get(
         &self,
         cache_key: &str,
-    ) -> Result<Option<(HttpResponse<Vec<u8>>, CachePolicy)>> {
-        let store: Store = match cacache::read(&self.path, cache_key).await {
-            Ok(d) => bincode::deserialize(&d)?,
-            Err(_e) => {
-                return Ok(None);
-            }
+    ) -> Result<Option<(HttpResponse, CachePolicy)>> {
+        let mut reader = match Reader::open(&self.path, cache_key).await {
+            Ok(reader) => reader,
+            Err(err) => match err {
+                cacache::Error::EntryNotFound(..) => return Ok(None),
+                _ => return Err(err.into()),
+            },
         };
-        Ok(Some((store.response, store.policy)))
-    }
 
-    async fn put(
-        &self,
-        cache_key: String,
-        response: HttpResponse<Vec<u8>>,
-        policy: CachePolicy,
-    ) -> Result<HttpResponse<Vec<u8>>> {
-        let data = Store { response: response.clone(), policy };
-        let bytes = bincode::serialize(&data)?;
-        cacache::write(&self.path, cache_key, bytes).await?;
-        Ok(response)
-    }
-
-    async fn delete(&self, cache_key: &str) -> Result<()> {
-        Ok(cacache::remove(&self.path, cache_key).await?)
-    }
-}
-
-#[cfg(feature = "cacache-async-std")]
-use futures_lite::{AsyncReadExt, AsyncWriteExt};
-#[cfg(feature = "cacache-tokio")]
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-#[async_trait::async_trait]
-impl CacheManager<cacache::Reader> for CACacheManager {
-    async fn get(
-        &self,
-        cache_key: &str,
-    ) -> Result<Option<(HttpResponse<cacache::Reader>, CachePolicy)>> {
-        // FIXME: match "entry not found" error to return None if occured
-        let mut reader = cacache::Reader::open(&self.path, cache_key).await?;
-
-        // Reading "header" part length
+        // Reading "head" part length
         let mut buf = [0u8; 4];
         reader.read_exact(&mut buf).await?;
         let store_len = u32::from_le_bytes(buf);
 
-        // Reading "header" part
-        let mut buf = Vec::<u8>::with_capacity(store_len as usize);
+        // Reading "head" part
+        let mut buf = vec![0; store_len as usize];
         reader.read_exact(buf.as_mut_slice()).await?;
-        let store: NoBodyStore = bincode::deserialize(&buf)?;
+        let store: Store = bincode::deserialize(&buf)?;
 
-        Ok(Some((HttpResponse::from_parts(store.parts, reader), store.policy)))
+        let body = match store.body_kind {
+            BodyKind::Full => {
+                let mut body = Vec::new();
+                reader.read_to_end(&mut body).await?;
+                Body { inner: crate::BodyInner::Full(body.into()) }
+            }
+            BodyKind::Streaming => Body {
+                inner: crate::BodyInner::Streaming(BoxBody::new(
+                    StreamBody::new(CACacheReaderStream::new(reader))
+                        .map_err(Into::into),
+                )),
+            },
+        };
+        Ok(Some((HttpResponse::from_parts(store.parts, body), store.policy)))
     }
 
     async fn put(
         &self,
         cache_key: String,
-        response: HttpResponse<cacache::Reader>,
+        response: HttpResponse,
         policy: CachePolicy,
-    ) -> Result<HttpResponse<cacache::Reader>> {
-        let mut writer =
-            cacache::Writer::create(&self.path, &cache_key).await?;
-        let (parts, mut body) = response.into_parts();
-        let data = NoBodyStore { parts, policy };
+    ) -> Result<HttpResponse> {
+        let mut writer = Writer::create(&self.path, &cache_key).await?;
+        let (parts, body) = response.into_parts();
+        let body_kind = match &body.inner {
+            crate::BodyInner::Full(_) => BodyKind::Full,
+            crate::BodyInner::Streaming(_) => BodyKind::Streaming,
+        };
+        let data = Store { parts, policy, body_kind };
         let bytes = bincode::serialize(&data)?;
+        let store_len = (bytes.len() as u32).to_le_bytes();
+
+        // Writing "head" part length
+        writer.write_all(&store_len).await?;
+
+        // Writing "head" part
         writer.write_all(&bytes).await?;
 
-        // I don't know why cacache::Reader does not implement AsyncBufRead
-        // Perform bufferized reading manually
-        const BUF_SIZE: usize = 1024;
-        let mut buf = [0u8; BUF_SIZE];
-        loop {
-            let len = body.read(&mut buf).await?;
-            writer.write_all(&buf[..len]).await?;
-            if len == 0 {
-                break;
+        // Writing body itself
+        match body.inner {
+            crate::BodyInner::Full(data) => {
+                writer.write_all(&data).await?;
+            }
+            crate::BodyInner::Streaming(box_body) => {
+                let mut stream = box_body.into_data_stream();
+                while let Some(chunk_result) = stream.next().await {
+                    let chunk = chunk_result?;
+                    writer.write_all(&chunk).await?;
+                }
             }
         }
         writer.commit().await?;
-        // FIXME: provide error instead of unwrapping
-        Ok(self.get(&cache_key).await?.unwrap().0)
+
+        // Safety: at this point we successfully created this cache entry,
+        // so it is safe to unwrap here (cacache::Error::EntryNotFound should be impossible).
+        // FIXME: does it make sense to return error here instead of unwrapping? If yes, then which error?
+        let (response, _) = self.get(&cache_key).await?.unwrap();
+
+        Ok(response)
     }
 
     async fn delete(&self, cache_key: &str) -> Result<()> {

--- a/http-cache/src/managers/cacache.rs
+++ b/http-cache/src/managers/cacache.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::{CacheManager, HttpResponse, Result};
+use crate::{CacheManager, HttpResponse, Parts, Result};
 
 use http_cache_semantics::CachePolicy;
 use serde::{Deserialize, Serialize};
@@ -21,7 +21,20 @@ impl Default for CACacheManager {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Store {
-    response: HttpResponse,
+    response: HttpResponse<Vec<u8>>,
+    policy: CachePolicy,
+}
+
+// Cache binary value layout:
+// [u32 - size of the NoBodyStore][NoBodyStore][response body bytes]
+// bincode works with pre-defined slice of bytes, so we need this u32 in front.
+
+// FIXME: this layout needs to be used for both CacheManager impls.
+// Otherwise user won't be able to use different impls with the same cache instance.
+
+#[derive(Debug, Deserialize, Serialize)]
+struct NoBodyStore {
+    parts: Parts,
     policy: CachePolicy,
 }
 
@@ -39,7 +52,7 @@ impl CacheManager for CACacheManager {
     async fn get(
         &self,
         cache_key: &str,
-    ) -> Result<Option<(HttpResponse, CachePolicy)>> {
+    ) -> Result<Option<(HttpResponse<Vec<u8>>, CachePolicy)>> {
         let store: Store = match cacache::read(&self.path, cache_key).await {
             Ok(d) => bincode::deserialize(&d)?,
             Err(_e) => {
@@ -52,13 +65,74 @@ impl CacheManager for CACacheManager {
     async fn put(
         &self,
         cache_key: String,
-        response: HttpResponse,
+        response: HttpResponse<Vec<u8>>,
         policy: CachePolicy,
-    ) -> Result<HttpResponse> {
+    ) -> Result<HttpResponse<Vec<u8>>> {
         let data = Store { response: response.clone(), policy };
         let bytes = bincode::serialize(&data)?;
         cacache::write(&self.path, cache_key, bytes).await?;
         Ok(response)
+    }
+
+    async fn delete(&self, cache_key: &str) -> Result<()> {
+        Ok(cacache::remove(&self.path, cache_key).await?)
+    }
+}
+
+#[cfg(feature = "cacache-async-std")]
+use futures_lite::{AsyncReadExt, AsyncWriteExt};
+#[cfg(feature = "cacache-tokio")]
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[async_trait::async_trait]
+impl CacheManager<cacache::Reader> for CACacheManager {
+    async fn get(
+        &self,
+        cache_key: &str,
+    ) -> Result<Option<(HttpResponse<cacache::Reader>, CachePolicy)>> {
+        // FIXME: match "entry not found" error to return None if occured
+        let mut reader = cacache::Reader::open(&self.path, cache_key).await?;
+
+        // Reading "header" part length
+        let mut buf = [0u8; 4];
+        reader.read_exact(&mut buf).await?;
+        let store_len = u32::from_le_bytes(buf);
+
+        // Reading "header" part
+        let mut buf = Vec::<u8>::with_capacity(store_len as usize);
+        reader.read_exact(buf.as_mut_slice()).await?;
+        let store: NoBodyStore = bincode::deserialize(&buf)?;
+
+        Ok(Some((HttpResponse::from_parts(store.parts, reader), store.policy)))
+    }
+
+    async fn put(
+        &self,
+        cache_key: String,
+        response: HttpResponse<cacache::Reader>,
+        policy: CachePolicy,
+    ) -> Result<HttpResponse<cacache::Reader>> {
+        let mut writer =
+            cacache::Writer::create(&self.path, &cache_key).await?;
+        let (parts, mut body) = response.into_parts();
+        let data = NoBodyStore { parts, policy };
+        let bytes = bincode::serialize(&data)?;
+        writer.write_all(&bytes).await?;
+
+        // I don't know why cacache::Reader does not implement AsyncBufRead
+        // Perform bufferized reading manually
+        const BUF_SIZE: usize = 1024;
+        let mut buf = [0u8; BUF_SIZE];
+        loop {
+            let len = body.read(&mut buf).await?;
+            writer.write_all(&buf[..len]).await?;
+            if len == 0 {
+                break;
+            }
+        }
+        writer.commit().await?;
+        // FIXME: provide error instead of unwrapping
+        Ok(self.get(&cache_key).await?.unwrap().0)
     }
 
     async fn delete(&self, cache_key: &str) -> Result<()> {

--- a/http-cache/src/test.rs
+++ b/http-cache/src/test.rs
@@ -207,23 +207,34 @@ mod with_cacache {
         manager
             .put(format!("{}:{}", GET, &url), http_res.clone(), policy.clone())
             .await?;
-        let data = manager.get(&format!("{}:{}", GET, &url)).await?;
+        let data: Option<(HttpResponse<Vec<u8>>, _)> =
+            manager.get(&format!("{}:{}", GET, &url)).await?;
         assert!(data.is_some());
         assert_eq!(data.unwrap().0.body, TEST_BODY);
         let clone = manager.clone();
-        let clonedata = clone.get(&format!("{}:{}", GET, &url)).await?;
+        let clonedata: Option<(HttpResponse<Vec<u8>>, _)> =
+            clone.get(&format!("{}:{}", GET, &url)).await?;
         assert!(clonedata.is_some());
         assert_eq!(clonedata.unwrap().0.body, TEST_BODY);
-        manager.delete(&format!("{}:{}", GET, &url)).await?;
-        let data = manager.get(&format!("{}:{}", GET, &url)).await?;
+        <CACacheManager as CacheManager>::delete(
+            &manager,
+            &format!("{}:{}", GET, &url),
+        )
+        .await?;
+        let data: Option<(HttpResponse<Vec<u8>>, _)> =
+            manager.get(&format!("{}:{}", GET, &url)).await?;
         assert!(data.is_none());
 
         manager.put(format!("{}:{}", GET, &url), http_res, policy).await?;
         manager.clear().await?;
-        let data = manager.get(&format!("{}:{}", GET, &url)).await?;
+        let data: Option<(HttpResponse<Vec<u8>>, _)> =
+            manager.get(&format!("{}:{}", GET, &url)).await?;
         assert!(data.is_none());
         std::fs::remove_dir_all("./http-cacache-test")?;
         Ok(())
+        // FIXME: looks like it will be pretty annoying to specify the type every time
+        // to distinguish between different CacheManager impls.
+        // Probably there is something I can do about it?
     }
 }
 


### PR DESCRIPTION
I'm creating this PR just to show some ideas. The code here is pretty ugly and should not be merged as is.

The main goal was to do some experiments with `HttpResponse::body` type - make it generic and see what happens.

Basically changes are:
- `HttpResponse` is now `HttpResponse<T = Vec<u8>>`
- `CacheManager` is now `CacheManager<R = Vec<u8>>`

I another impl to `CACacheManager`: `CacheManager<cacache::Reader>` which doesn't read the whole body of HTTP response into memory at once. However now when I'm looking at it I think I messed up here cause I don't see a clear way to use `cacache::Reader` for user as an input. Probably some additional interface inside `http-cache` itself is needed here.

I don't see any way to achieve this without breaking changes though - and this is probably concerning,

Again this is just WIP on some ideas, not a ready-to-go code suggestion.