### PR TITLE
chore(docs): update MSRV

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,17 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "cargo"
-    directory: "/"
-    target-branch: "develop"
+    directories:
+      - "/"
+      - "/http-cache"
+      - "/http-cache-darkbird"
+      - "/http-cache-mokadeser"
+      - "/http-cache-quickcache"
+      - "/http-cache-reqwest"
+      - "/http-cache-surf"
     schedule:
       interval: "weekly"
     ignore:
         # These are peer deps of Cargo and should not be automatically bumped
         - dependency-name: "semver"
         - dependency-name: "crates-io"
-    rebase-strategy: "disabled"

--- a/.github/workflows/http-cache-darkbird.yml
+++ b/.github/workflows/http-cache-darkbird.yml
@@ -36,7 +36,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/http-cache-mokadeser.yml
+++ b/.github/workflows/http-cache-mokadeser.yml
@@ -36,7 +36,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/http-cache-quickcache.yml
+++ b/.github/workflows/http-cache-quickcache.yml
@@ -36,7 +36,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/http-cache-reqwest.yml
+++ b/.github/workflows/http-cache-reqwest.yml
@@ -36,7 +36,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/http-cache-surf.yml
+++ b/.github/workflows/http-cache-surf.yml
@@ -36,7 +36,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/http-cache.yml
+++ b/.github/workflows/http-cache.yml
@@ -36,7 +36,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,6 +17,15 @@ jobs:
   test:
     name: Verify MSRV
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - http-cache
+          - http-cache-darkbird
+          - http-cache-mokadeser
+          - http-cache-quickcache
+          - http-cache-reqwest
+          - http-cache-surf
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -24,18 +33,5 @@ jobs:
         with:
           tool: cargo-binstall
       - run: cargo binstall --version 0.18.4 --no-confirm cargo-msrv
-      - name: Run cargo msrv http-cache
-        working-directory: ./http-cache
-        run: cargo msrv verify
-      - name: Run cargo msrv http-cache-quickcache
-        working-directory: ./http-cache-quickcache
-        run: cargo msrv verify
-      - name: Run cargo msrv http-cache-darkbird
-        working-directory: ./http-cache-darkbird
-        run: cargo msrv verify
-      - name: Run cargo msrv http-cache-reqwest
-        working-directory: ./http-cache-reqwest
-        run: cargo msrv verify
-      - name: Run cargo msrv http-cache-surf
-        working-directory: ./http-cache-surf
-        run: cargo msrv verify
+      - name: cargo msrv verify ${{ matrix.path }}
+        run: cargo msrv verify --path ${{ matrix.path }}

--- a/http-cache-darkbird/README.md
+++ b/http-cache-darkbird/README.md
@@ -12,7 +12,7 @@ An http-cache manager implementation for [darkbird](https://github.com/Rustixir/
 
 ## Minimum Supported Rust Version (MSRV)
 
-1.71.1
+1.81.0
 
 ## Install
 

--- a/http-cache-mokadeser/README.md
+++ b/http-cache-mokadeser/README.md
@@ -12,7 +12,7 @@ An http-cache manager implementation for [moka](https://github.com/moka-rs/moka)
 
 ## Minimum Supported Rust Version (MSRV)
 
-1.71.1
+1.81.0
 
 ## Install
 

--- a/http-cache-quickcache/README.md
+++ b/http-cache-quickcache/README.md
@@ -12,7 +12,7 @@ An http-cache manager implementation for [quick-cache](https://github.com/arthur
 
 ## Minimum Supported Rust Version (MSRV)
 
-1.71.1
+1.81.0
 
 ## Install
 

--- a/http-cache-reqwest/README.md
+++ b/http-cache-reqwest/README.md
@@ -15,7 +15,7 @@ Uses [reqwest-middleware](https://github.com/TrueLayer/reqwest-middleware) for m
 
 ## Minimum Supported Rust Version (MSRV)
 
-1.71.1
+1.81.0
 
 ## Install
 

--- a/http-cache-surf/README.md
+++ b/http-cache-surf/README.md
@@ -15,7 +15,7 @@ Should likely be registered after any middleware modifying the request.
 
 ## Minimum Supported Rust Version (MSRV)
 
-1.71.1
+1.81.0
 
 ## Install
 

--- a/http-cache/README.md
+++ b/http-cache/README.md
@@ -20,7 +20,7 @@ See the [Provided Client Implementations](#provided-client-implementations) sect
 
 ## Minimum Supported Rust Version (MSRV)
 
-1.71.1
+1.81.0
 
 ## Install
 


### PR DESCRIPTION
### Changes
- Update MSRV in documentation
- Add missing crates to Dependabot and msrv
- There is no `target-branch: "develop"`, Dependabot is merging into main
- Rebases had to be triggered manually, so `rebase-strategy: "disabled"` has been removed
- GitHub Runners are lower-case

### Unchanged
- [anymap](https://github.com/chris-morgan/anymap) is not maintained anymore, if you would want to fix the critical 9.8/10 [CVE-2021-38187](https://rustsec.org/advisories/RUSTSEC-2021-0065.html) you would have to bump your dependency at least to [1.0.0-beta.1](https://github.com/chris-morgan/anymap/releases/tag/1.0.0-beta.1)