### PR TITLE
Serialize all header values, instead of just the first, fixes #119

### DIFF
--- a/http-cache-reqwest/src/lib.rs
+++ b/http-cache-reqwest/src/lib.rs
@@ -279,9 +279,7 @@ pub type ReqwestStreamingError = http_cache::ClientStreamingError;
 #[cfg(feature = "streaming")]
 use http_cache::StreamingCacheManager;
 
-use std::{
-    collections::HashMap, convert::TryInto, str::FromStr, time::SystemTime,
-};
+use std::{convert::TryInto, str::FromStr, time::SystemTime};
 
 pub use http::request::Parts;
 use http::{
@@ -443,13 +441,7 @@ impl Middleware for ReqwestMiddleware<'_> {
             .run(copied_req, self.extensions)
             .await
             .map_err(BoxError::from)?;
-        let mut headers = HashMap::new();
-        for header in res.headers() {
-            headers.insert(
-                header.0.as_str().to_owned(),
-                header.1.to_str()?.to_owned(),
-            );
-        }
+        let headers = res.headers().into();
         let url = res.url().clone();
         let status = res.status().into();
         let version = res.version();

--- a/http-cache-surf/src/lib.rs
+++ b/http-cache-surf/src/lib.rs
@@ -144,8 +144,8 @@
 //! ```
 
 use std::convert::TryInto;
+use std::str::FromStr;
 use std::time::SystemTime;
-use std::{collections::HashMap, str::FromStr};
 
 use http::{
     header::CACHE_CONTROL,
@@ -155,7 +155,7 @@ use http_cache::{
     BadHeader, BoxError, CacheManager, CacheOptions, HitOrMiss, HttpResponse,
     Middleware, Result, XCACHE, XCACHELOOKUP,
 };
-pub use http_cache::{CacheMode, HttpCache};
+pub use http_cache::{CacheMode, HttpCache, HttpHeaders};
 use http_cache_semantics::CachePolicy;
 use http_types::{
     headers::HeaderValue as HttpTypesHeaderValue,
@@ -258,7 +258,7 @@ impl Middleware for SurfMiddleware<'_> {
         let url = self.req.url().clone();
         let mut res =
             self.next.run(self.req.clone().into(), self.client.clone()).await?;
-        let mut headers = HashMap::new();
+        let mut headers = HttpHeaders::new();
         for header in res.iter() {
             headers.insert(
                 header.0.as_str().to_owned(),

--- a/http-cache-ureq/src/lib.rs
+++ b/http-cache-ureq/src/lib.rs
@@ -584,11 +584,14 @@ impl<'a, T: CacheManager> CachedRequestBuilder<'a, T> {
             if cache_status_headers {
                 cached_response
                     .headers
-                    .insert(XCACHE.to_string(), HitOrMiss::MISS.to_string());
-                cached_response.headers.insert(
-                    XCACHELOOKUP.to_string(),
-                    HitOrMiss::MISS.to_string(),
-                );
+                    .entry(XCACHE.to_string())
+                    .or_insert_with(Vec::new)
+                    .push(HitOrMiss::MISS.to_string());
+                cached_response
+                    .headers
+                    .entry(XCACHELOOKUP.to_string())
+                    .or_insert_with(Vec::new)
+                    .push(HitOrMiss::MISS.to_string());
             }
 
             Ok(cached_response)
@@ -664,18 +667,9 @@ fn convert_ureq_response_to_http_response(
     url: &str,
 ) -> Result<HttpResponse, HttpCacheError> {
     let status = response.status();
-    let mut headers = HashMap::new();
 
     // Copy headers
-    for (name, value) in response.headers() {
-        let value_str = value.to_str().map_err(|e| {
-            HttpCacheError::http(Box::new(std::io::Error::other(format!(
-                "Invalid header value: {}",
-                e
-            ))))
-        })?;
-        headers.insert(name.as_str().to_string(), value_str.to_string());
-    }
+    let headers = response.headers().into();
 
     // Read body using read_to_string
     let body_string = response.body_mut().read_to_string().map_err(|e| {
@@ -708,7 +702,7 @@ fn convert_ureq_response_to_http_response(
 #[derive(Debug)]
 pub struct CachedResponse {
     status: u16,
-    headers: HashMap<String, String>,
+    headers: HashMap<String, Vec<String>>,
     body: Vec<u8>,
     url: String,
     cached: bool,
@@ -727,7 +721,9 @@ impl CachedResponse {
 
     /// Get a header value
     pub fn header(&self, name: &str) -> Option<&str> {
-        self.headers.get(name).map(|s| s.as_str())
+        self.headers
+            .get(name)
+            .and_then(|values| values.first().map(|s| s.as_str()))
     }
 
     /// Get all header names
@@ -786,7 +782,10 @@ impl CachedResponse {
         let mut headers = HashMap::new();
         for (name, value) in response.headers() {
             let value_str = value.to_str().unwrap_or("");
-            headers.insert(name.as_str().to_string(), value_str.to_string());
+            headers
+                .entry(name.as_str().to_string())
+                .or_insert_with(Vec::new)
+                .push(value_str.to_string());
         }
 
         // Note: Cache headers will be added by the cache system based on cache_status_headers option
@@ -810,7 +809,7 @@ impl From<HttpResponse> for CachedResponse {
         // based on the cache_status_headers option, so don't add them here
         Self {
             status: response.status,
-            headers: response.headers,
+            headers: response.headers.into(),
             body: response.body,
             url: response.url.to_string(),
             cached: true,


### PR DESCRIPTION
Added backwards compatibility to the previous format ensuring data isn't lost for consumers of the crate who upgrade.