### PR TITLE
update reqwest to 0.13.1

### DIFF
--- a/http-cache-reqwest/Cargo.toml
+++ b/http-cache-reqwest/Cargo.toml
@@ -2,16 +2,16 @@
 name = "http-cache-reqwest"
 version = "1.0.0-alpha.2"
 description = "http-cache middleware implementation for reqwest"
-authors = ["Christian Haynes <06chaynes@gmail.com>", "Kat Marchán <kzm@zkat.tech>"]
+authors = [
+    "Christian Haynes <06chaynes@gmail.com>",
+    "Kat Marchán <kzm@zkat.tech>",
+]
 repository = "https://github.com/06chaynes/http-cache"
 homepage = "https://http-cache.rs"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["cache", "http", "middleware", "reqwest"]
-categories = [
-    "caching",
-    "web-programming::http-client"
-]
+categories = ["caching", "web-programming::http-client"]
 edition = "2021"
 rust-version = "1.83.0"
 
@@ -23,8 +23,10 @@ http = "1.2.0"
 http-body = "1.0.1"
 http-body-util = "0.1.2"
 http-cache-semantics = "2.1.0"
-reqwest = { version = "0.12.12", default-features = false }
-reqwest-middleware = "0.4.0"
+reqwest = { version = "0.13.1", default-features = false, features = [
+    "stream",
+] }
+reqwest-middleware = "0.5.0"
 url = { version = "2.5.4", features = ["serde"] }
 
 # Optional dependencies for streaming feature


### PR DESCRIPTION
Bumps reqwest to 0.13.1, which includes updating reqwest-middleware.

Verified with `cargo build && cargo test.`