### PR TITLE
bump reqwest and reqwest-middleware versions

### DIFF
--- a/http-cache-reqwest/Cargo.toml
+++ b/http-cache-reqwest/Cargo.toml
@@ -20,8 +20,8 @@ anyhow = "1.0.95"
 async-trait = "0.1.85"
 http = "1.2.0"
 http-cache-semantics = "2.1.0"
-reqwest = { version = "0.12.12", default-features = false }
-reqwest-middleware = "0.4.0"
+reqwest = { version = "0.13.1", default-features = false }
+reqwest-middleware = "0.5.0"
 serde = { version = "1.0.217", features = ["derive"] }
 url = { version = "2.5.4", features = ["serde"] }
 


### PR DESCRIPTION
bump reqwest and reqwest-middleware versions, matched the date to the correct commit to ensure this matches the 0.16.0 release of http-cache-reqwest.